### PR TITLE
Changed Fetch Policy for `currentUser` Query.

### DIFF
--- a/lib/shopify/src/shopify_auth.dart
+++ b/lib/shopify/src/shopify_auth.dart
@@ -1,7 +1,7 @@
 import 'dart:developer';
 
 import 'package:graphql_flutter/graphql_flutter.dart';
-export 'package:graphql/client.dart';
+import 'package:graphql/client.dart';
 import 'package:shopify_flutter/mixins/src/shopify_error.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/shopify/src/shopify_auth.dart
+++ b/lib/shopify/src/shopify_auth.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:graphql/src/core/policies.dart';
 import 'package:shopify_flutter/mixins/src/shopify_error.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -283,7 +284,7 @@ class ShopifyAuth with ShopifyError {
     final WatchQueryOptions _getCustomer = WatchQueryOptions(
       document: gql(getCustomerQuery),
       variables: {'customerAccessToken': await currentCustomerAccessToken},
-      fetchPolicy: ShopifyConfig.fetchPolicy,
+      fetchPolicy: FetchPolicy.networkOnly,
     );
     if (_shopifyUser.containsKey(ShopifyConfig.storeUrl)) {
       return _shopifyUser[ShopifyConfig.storeUrl];

--- a/lib/shopify/src/shopify_auth.dart
+++ b/lib/shopify/src/shopify_auth.dart
@@ -1,7 +1,7 @@
 import 'dart:developer';
 
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:graphql/src/core/policies.dart';
+import 'package:graphql_flutter/src/core/policies.dart';
 import 'package:shopify_flutter/mixins/src/shopify_error.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/shopify/src/shopify_auth.dart
+++ b/lib/shopify/src/shopify_auth.dart
@@ -1,7 +1,7 @@
 import 'dart:developer';
 
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:graphql_flutter/src/core/policies.dart';
+export 'package:graphql/client.dart';
 import 'package:shopify_flutter/mixins/src/shopify_error.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/shopify/src/shopify_auth.dart
+++ b/lib/shopify/src/shopify_auth.dart
@@ -1,7 +1,6 @@
 import 'dart:developer';
 
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:graphql/client.dart';
 import 'package:shopify_flutter/mixins/src/shopify_error.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';


### PR DESCRIPTION
Using cache is important to reduce the load on APIs, and to reduce loading times, but for things that may change frequently during the runtime, it would be better to go with network-only policy.

The `ShopifyConfig.fetchPolicy` sets the policy for all the queries, so if you want to use cache for products and collections, you'll have to opt-in to cache-first policy for all the queries. In case of `currentUser` query, I think this policy is not good, as the user will update their profile from the app. Some updates can be handled locally, but others may result in inconsistent data.

To resolve this, I have hardcoded the `fetchPolicy` for the `currentUser` query, as `FetchPolicy.networkOnly`.