### PR TITLE
Fix blogByHandle query

### DIFF
--- a/lib/graphql_operations/storefront/queries/get_blog_by_handle.dart
+++ b/lib/graphql_operations/storefront/queries/get_blog_by_handle.dart
@@ -39,14 +39,14 @@ query($handle : String!, $sortKey: ArticleSortKeys, $reverseArticles: Boolean){
           publishedAt
           tags
           title
-          url
+          onlineStoreUrl
         }
       }
     }
     handle
     id
     title
-    url
+    onlineStoreUrl
   }
 }
 ''';


### PR DESCRIPTION
Field 'url' doesn't exist on type 'Blog', so to fix it we simply replace it with 'onlineStoreUrl'.