### PR TITLE
Add null filtering in the getProductsByIds interface.

### DIFF
--- a/lib/shopify/src/shopify_store.dart
+++ b/lib/shopify/src/shopify_store.dart
@@ -115,9 +115,15 @@ class ShopifyStore with ShopifyError {
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
     var response = result.data!;
+    // var newResponse = {
+    //   'edges': List.generate(response['nodes'].length,
+    //       (index) => {'node': response['nodes'][index]})
+    // };
     var newResponse = {
-      'edges': List.generate(response['nodes'].length,
-          (index) => {'node': response['nodes'][index]})
+      'edges': List.generate(response['nodes'].length, (index) {
+        var node = response['nodes'][index];
+        return node != null ? {'node': node} : null;
+      }).where((edge) => edge != null).toList()
     };
     productList = Products.fromGraphJson(newResponse).productList;
     return productList;


### PR DESCRIPTION
When the APP API configured in shopify background is unavailable, json-to-model can't be converted normally because of null error, so null filtering is added.