### PR TITLE
Add Metafields to Products and Collections

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -77,16 +77,13 @@ class MyHomePageState extends State<MyHomePage> {
         unselectedItemColor: Colors.black,
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.category), label: 'Collections'),
+          BottomNavigationBarItem(icon: Icon(Icons.category), label: 'Collections'),
           BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Search'),
           BottomNavigationBarItem(icon: Icon(Icons.shopify), label: 'Shop'),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.book_online_outlined), label: 'Blog'),
+          BottomNavigationBarItem(icon: Icon(Icons.book_online_outlined), label: 'Blog'),
           // BottomNavigationBarItem(
           //     icon: Icon(Icons.checkroom_outlined), label: 'Checkout'),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.shopping_cart), label: 'Cart'),
+          BottomNavigationBarItem(icon: Icon(Icons.shopping_cart), label: 'Cart'),
           BottomNavigationBarItem(icon: Icon(Icons.history), label: 'Orders'),
           BottomNavigationBarItem(icon: Icon(Icons.login), label: 'Login'),
         ],

--- a/example/lib/screens/blog_tab.dart
+++ b/example/lib/screens/blog_tab.dart
@@ -52,9 +52,7 @@ class BlogTabState extends State<BlogTab> {
               padding: const EdgeInsets.all(8),
               itemCount: blogs.length,
               itemBuilder: (_, int index) => ListTile(
-                  title: blogs[index].title == null
-                      ? const Text('No Title')
-                      : Text(blogs[index].title!),
+                  title: blogs[index].title == null ? const Text('No Title') : Text(blogs[index].title!),
                   trailing: const Icon(Icons.arrow_forward_ios),
                   onTap: () {
                     if (blogs[index].articles != null) {
@@ -89,8 +87,7 @@ class BlogTabState extends State<BlogTab> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) =>
-                          PagePage(handle: pages[index].title),
+                      builder: (context) => PagePage(handle: pages[index].title),
                     ),
                   );
                 },

--- a/example/lib/screens/cart_tab.dart
+++ b/example/lib/screens/cart_tab.dart
@@ -421,8 +421,7 @@ class _BuyerIndetityState extends State<BuyerIndetity> {
 
   String randomString(int n) {
     var text = "";
-    var possible =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     for (var i = 0; i < n; i++) {
       text += possible[Random().nextInt(possible.length)];
     }
@@ -519,15 +518,13 @@ class _BuyerIndetityState extends State<BuyerIndetity> {
                     initiallyExpanded: true,
                     title: const Text('Delivery Address Preferences'),
                     children: [
-                      if (buyerIndetity?.deliveryAddressPreferences?.isEmpty ??
-                          true)
+                      if (buyerIndetity?.deliveryAddressPreferences?.isEmpty ?? true)
                         const ListTile(
                           title: Text('No delivery address preferences'),
                         ),
                       ...(buyerIndetity?.deliveryAddressPreferences ?? []).map(
                         (mailingAddress) => ListTile(
-                          title: Text(
-                              '${mailingAddress?.firstName} ${mailingAddress?.lastName}'),
+                          title: Text('${mailingAddress?.firstName} ${mailingAddress?.lastName}'),
                           subtitle: Column(
                             mainAxisSize: MainAxisSize.min,
                             crossAxisAlignment: CrossAxisAlignment.start,

--- a/example/lib/screens/checkout_page.dart
+++ b/example/lib/screens/checkout_page.dart
@@ -25,8 +25,7 @@ class _CheckoutPageState extends State<CheckoutPage> {
 
     try {
       setState(() => _isLoading = true);
-      await shopifyAuth.signInWithEmailAndPassword(
-          email: kUserEmail, password: kUserPassword);
+      await shopifyAuth.signInWithEmailAndPassword(email: kUserEmail, password: kUserPassword);
 
       final bestSellingProducts = await shopifyStore.getNProducts(
         10,
@@ -97,8 +96,7 @@ class _CheckoutPageState extends State<CheckoutPage> {
 
     try {
       setState(() => _isLoading = true);
-      await shopifyAuth.signInWithEmailAndPassword(
-          email: kUserEmail, password: kUserPassword);
+      await shopifyAuth.signInWithEmailAndPassword(email: kUserEmail, password: kUserPassword);
 
       final bestSellingProducts = await shopifyStore.getNProducts(
         10,
@@ -174,8 +172,7 @@ class _CheckoutPageState extends State<CheckoutPage> {
 
       final idempotencyKey = UniqueKey().toString();
       await shopifyCheckout.shippingAddressUpdate(checkout.id, address);
-      final tokanizedCheckout =
-          await shopifyCheckout.checkoutCompleteWithTokenizedPaymentV3(
+      final tokanizedCheckout = await shopifyCheckout.checkoutCompleteWithTokenizedPaymentV3(
         checkout.id,
         checkout: checkout,
         token: r'CQ32pyIRCmIEfekpX8x=',

--- a/example/lib/screens/collection_tab.dart
+++ b/example/lib/screens/collection_tab.dart
@@ -28,8 +28,7 @@ class CollectionTabState extends State<CollectionTab> {
             : ListView.builder(
                 itemCount: collections.length,
                 itemBuilder: (_, int index) => ListTile(
-                  onTap: () => _navigateToCollectionDetailScreen(
-                      collections[index].id, collections[index].title),
+                  onTap: () => _navigateToCollectionDetailScreen(collections[index].id, collections[index].title),
                   title: Text(collections[index].title),
                 ),
               ),
@@ -52,21 +51,18 @@ class CollectionTabState extends State<CollectionTab> {
     }
   }
 
-  void _navigateToCollectionDetailScreen(
-      String collectionId, String collectionTitle) {
+  void _navigateToCollectionDetailScreen(String collectionId, String collectionTitle) {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) =>
-            CollectionDetailScreen(collectionId: collectionId),
+        builder: (context) => CollectionDetailScreen(collectionId: collectionId),
       ),
     );
   }
 }
 
 class CollectionDetailScreen extends StatefulWidget {
-  const CollectionDetailScreen({Key? key, required this.collectionId})
-      : super(key: key);
+  const CollectionDetailScreen({Key? key, required this.collectionId}) : super(key: key);
   final String collectionId;
 
   @override
@@ -108,8 +104,7 @@ class CollectionDetailScreenState extends State<CollectionDetailScreen> {
   Future<void> _fetchProductsByCollectionId() async {
     try {
       final shopifyStore = ShopifyStore.instance;
-      final products =
-          await shopifyStore.getXProductsAfterCursorWithinCollection(
+      final products = await shopifyStore.getXProductsAfterCursorWithinCollection(
         widget.collectionId,
         4,
         startCursor: null,
@@ -132,8 +127,7 @@ class CollectionDetailScreenState extends State<CollectionDetailScreen> {
   Future<void> _fetchCollectionDetail() async {
     try {
       final shopifyStore = ShopifyStore.instance;
-      final collectionInfo =
-          await shopifyStore.getCollectionById(widget.collectionId);
+      final collectionInfo = await shopifyStore.getCollectionById(widget.collectionId);
       setState(() {
         collection = collectionInfo;
       });

--- a/example/lib/screens/home_tab.dart
+++ b/example/lib/screens/home_tab.dart
@@ -42,8 +42,7 @@ class HomeTabState extends State<HomeTab> {
                   crossAxisSpacing: 8,
                 ),
                 itemCount: products.length,
-                itemBuilder: (_, int index) =>
-                    _buildProductThumbnail(products[index]),
+                itemBuilder: (_, int index) => _buildProductThumbnail(products[index]),
               ),
       ),
     );

--- a/example/lib/screens/product_detail_screen.dart
+++ b/example/lib/screens/product_detail_screen.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:shopify_flutter/shopify_flutter.dart';
 
 class ProductDetailScreen extends StatefulWidget {
-  const ProductDetailScreen({Key? key, required this.product})
-      : super(key: key);
+  const ProductDetailScreen({Key? key, required this.product}) : super(key: key);
   final Product product;
 
   @override

--- a/example/lib/screens/shop_tab.dart
+++ b/example/lib/screens/shop_tab.dart
@@ -81,8 +81,7 @@ query{
   Future<void> _fetchLocalizationInfo() async {
     try {
       setState(() => _isLoading = true);
-      final localizationInfo =
-          await ShopifyLocalization.instance.getLocalization();
+      final localizationInfo = await ShopifyLocalization.instance.getLocalization();
       if (mounted) {
         setState(() {
           localization = localizationInfo;
@@ -139,25 +138,20 @@ query{
                   ),
                   ListTile(
                     title: const Text('Supported Languages'),
-                    subtitle: Text(localization?.availableLanguages
-                            .map((lang) => lang.name)
-                            .toList()
-                            .join(', ') ??
-                        'N/A'),
+                    subtitle:
+                        Text(localization?.availableLanguages.map((lang) => lang.name).toList().join(', ') ?? 'N/A'),
                   ),
                   ListTile(
                     title: const Text('Supported Currencies'),
                     subtitle: Text(localization?.availableCountries
-                            .map((country) =>
-                                '${country.currency.name} (${country.currency.symbol})')
+                            .map((country) => '${country.currency.name} (${country.currency.symbol})')
                             .toSet()
                             .join(', ') ??
                         'N/A'),
                   ),
                   ListTile(
                     title: const Text('Primary Domain SSL Enabled'),
-                    subtitle:
-                        Text(shop?.primaryDomain?.sslEnabled.toString() ?? ''),
+                    subtitle: Text(shop?.primaryDomain?.sslEnabled.toString() ?? ''),
                   ),
                   ListTile(
                     title: const Text('Privacy Policy'),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,15 +5,15 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   alerter:
     dependency: "direct main"
     description:
@@ -26,10 +26,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   args:
     dependency: transitive
     description:
@@ -138,10 +138,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   connectivity_plus:
     dependency: transitive
     description:
@@ -585,18 +585,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -891,12 +891,12 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.3.3"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -941,10 +941,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -957,10 +957,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   synchronized:
     dependency: transitive
     description:
@@ -981,10 +981,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -1141,10 +1141,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   wakelock_plus:
     dependency: transitive
     description:

--- a/lib/graphql_operations/storefront/queries/get_all_collections_optimized.dart
+++ b/lib/graphql_operations/storefront/queries/get_all_collections_optimized.dart
@@ -1,6 +1,6 @@
 /// Query to get all collections
 const String getAllCollectionsOptimizedQuery = r'''
-query($cursor: String, $sortKey: CollectionSortKeys, $reverse: Boolean){
+query($metafields: [HasMetafieldsIdentifier!]!, $cursor: String, $sortKey: CollectionSortKeys, $reverse: Boolean){
   collections(first: 250, after: $cursor, sortKey: $sortKey, reverse: $reverse) {
   pageInfo{
     hasNextPage
@@ -18,6 +18,23 @@ query($cursor: String, $sortKey: CollectionSortKeys, $reverse: Boolean){
           altText
           id
           originalSrc
+        }
+        metafields(identifiers: $metafields) {
+          id
+          type
+          key
+          namespace
+          value
+          description
+          reference {
+            ... on MediaImage {
+              image {
+                originalSrc
+                url
+                id
+              }
+            }
+          }
         }
       }
     }

--- a/lib/graphql_operations/storefront/queries/get_all_products_from_collection_by_id.dart
+++ b/lib/graphql_operations/storefront/queries/get_all_products_from_collection_by_id.dart
@@ -1,6 +1,6 @@
 /// get all related products from collection by id
 const String getAllProductsFromCollectionByIdQuery = r'''
-query($id : ID!, $cursor : String, $sortKey: ProductCollectionSortKeys, $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $id : ID!, $cursor : String, $sortKey: ProductCollectionSortKeys, $country: CountryCode)  @inContext(country: $country){
   node(id: $id) {
     ... on Collection {
       id
@@ -22,7 +22,24 @@ query($id : ID!, $cursor : String, $sortKey: ProductCollectionSortKeys, $country
             id
             name
             values
-            } 
+          }
+          metafields(identifiers: $metafields) {
+            id
+            type
+            key
+            namespace
+            value
+            description
+            reference {
+              ... on MediaImage {
+                image {
+                  originalSrc
+                  url
+                  id
+                }
+              }
+            }
+          }
             availableForSale
             collections(first: 250) {
               edges {

--- a/lib/graphql_operations/storefront/queries/get_all_products_on_query.dart
+++ b/lib/graphql_operations/storefront/queries/get_all_products_on_query.dart
@@ -1,6 +1,6 @@
 /// Query to get all products on query
 const String getAllProductsOnQueryQuery = r'''
-query( $cursor: String, $sortKey : ProductSortKeys, $query: String, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $cursor: String, $sortKey : ProductSortKeys, $query: String, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
   products(query: $query, first: 250, after: $cursor, sortKey: $sortKey, reverse: $reverse) {
     edges {
       node {
@@ -8,7 +8,24 @@ query( $cursor: String, $sortKey : ProductSortKeys, $query: String, $reverse: Bo
             id
             name
             values
-            } 
+            }
+          metafields(identifiers: $metafields) {
+            id
+            type
+            key
+            namespace
+            value
+            description
+            reference {
+              ... on MediaImage {
+                image {
+                  originalSrc
+                  url
+                  id
+                }
+              }
+            }
+          }
         id
         handle
         availableForSale

--- a/lib/graphql_operations/storefront/queries/get_collections.dart
+++ b/lib/graphql_operations/storefront/queries/get_collections.dart
@@ -1,6 +1,6 @@
 /// Query to get all collections
 const String getAllCollectionsQuery = r'''
-query($cursor: String, $sortKey: CollectionSortKeys, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $cursor: String, $sortKey: CollectionSortKeys, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
   collections(first: 250, after: $cursor, sortKey: $sortKey, reverse: $reverse) {
   pageInfo{
     hasNextPage
@@ -14,6 +14,23 @@ query($cursor: String, $sortKey: CollectionSortKeys, $reverse: Boolean, $country
         handle
         id
         updatedAt
+        metafields(identifiers: $metafields) {
+          id
+          type
+          key
+          namespace
+          value
+          description
+          reference {
+            ... on MediaImage {
+              image {
+                originalSrc
+                url
+                id
+              }
+            }
+          }
+        }
         image {
           altText
           id

--- a/lib/graphql_operations/storefront/queries/get_collections_by_ids.dart
+++ b/lib/graphql_operations/storefront/queries/get_collections_by_ids.dart
@@ -1,9 +1,26 @@
 /// Query to get collections by ids
 const String getCollectionsByIdsQuery = r'''
-query getCollectionsByIds($ids: [ID!]!){
+query getCollectionsByIds($metafields: [HasMetafieldsIdentifier!]!, $ids: [ID!]!){
   nodes(ids: $ids) {
     ... on Collection {
       id
+      metafields(identifiers: $metafields) {
+        id
+        type
+        key
+        namespace
+        value
+        description
+        reference {
+          ... on MediaImage {
+            image {
+              originalSrc
+              url
+              id
+            }
+          }
+        }
+      }
       handle
       descriptionHtml
       image {

--- a/lib/graphql_operations/storefront/queries/get_featured_collections.dart
+++ b/lib/graphql_operations/storefront/queries/get_featured_collections.dart
@@ -1,6 +1,6 @@
 /// Query to get featured collection
 const String getFeaturedCollectionQuery = r'''
-query getFeaturedCollectionQuery($query: String!, $country: CountryCode)  @inContext(country: $country){
+query getFeaturedCollectionQuery($metafields: [HasMetafieldsIdentifier!]!, $query: String!, $country: CountryCode)  @inContext(country: $country){
   collections(query: $query, first: 1) {
     edges {
       node {
@@ -10,6 +10,23 @@ query getFeaturedCollectionQuery($query: String!, $country: CountryCode)  @inCon
         handle
         id
         updatedAt
+        metafields(identifiers: $metafields) {
+          id
+          type
+          key
+          namespace
+          value
+          description
+          reference {
+            ... on MediaImage {
+              image {
+                originalSrc
+                url
+                id
+              }
+            }
+          }
+        }
         image {
           altText
           id

--- a/lib/graphql_operations/storefront/queries/get_n_products.dart
+++ b/lib/graphql_operations/storefront/queries/get_n_products.dart
@@ -1,6 +1,6 @@
 /// Query to get n products
 const String getNProductsQuery = r'''
-query($country: CountryCode, $n : Int, $sortKey : ProductSortKeys, $reverse: Boolean) @inContext(country: $country) {
+query($metafields: [HasMetafieldsIdentifier!]!, $country: CountryCode, $n : Int, $sortKey : ProductSortKeys, $reverse: Boolean) @inContext(country: $country) {
   products(first: $n, sortKey: $sortKey, reverse: $reverse) {
     pageInfo {
       hasNextPage
@@ -12,7 +12,24 @@ query($country: CountryCode, $n : Int, $sortKey : ProductSortKeys, $reverse: Boo
             id
             name
             values
-            } 
+            }
+          metafields(identifiers: $metafields) {
+            id
+            type
+            key
+            namespace
+            value
+            description
+            reference {
+              ... on MediaImage {
+                image {
+                  originalSrc
+                  url
+                  id
+                }
+              }
+            }
+          }
         variants(first: 250) {
           edges {
             node {

--- a/lib/graphql_operations/storefront/queries/get_product_by_handle.dart
+++ b/lib/graphql_operations/storefront/queries/get_product_by_handle.dart
@@ -1,11 +1,28 @@
 /// Query to get product by handle
 const String getProductByHandleQuery = r'''
-query getProductByHandle($country: CountryCode, $handle: String!) @inContext(country: $country) {
+query getProductByHandle($metafields: [HasMetafieldsIdentifier!]!, $country: CountryCode, $handle: String!) @inContext(country: $country) {
   productByHandle(handle: $handle) {
     options(first: 50) {
       id
       name
       values
+    }
+    metafields(identifiers: $metafields) {
+      id
+      type
+      key
+      namespace
+      value
+      description
+      reference {
+        ... on MediaImage {
+          image {
+            originalSrc
+            url
+            id
+          }
+        }
+      }
     }
     id
     handle

--- a/lib/graphql_operations/storefront/queries/get_product_recommendations.dart
+++ b/lib/graphql_operations/storefront/queries/get_product_recommendations.dart
@@ -1,6 +1,6 @@
 /// Query to get product recommendations
 const String getProductRecommendationsQuery = r'''
-query getProductRecommentationsQuery($id: ID!, $country: CountryCode)  @inContext(country: $country){
+query getProductRecommentationsQuery($metafields: [HasMetafieldsIdentifier!]!, $id: ID!, $country: CountryCode)  @inContext(country: $country){
   productRecommendations(productId: $id) {
     availableForSale
     createdAt
@@ -36,6 +36,23 @@ query getProductRecommentationsQuery($id: ID!, $country: CountryCode)  @inContex
       id
       name
       values
+    }
+    metafields(identifiers: $metafields) {
+      id
+      type
+      key
+      namespace
+      value
+      description
+      reference {
+        ... on MediaImage {
+          image {
+            originalSrc
+            url
+            id
+          }
+        }
+      }
     }
     productType
     publishedAt

--- a/lib/graphql_operations/storefront/queries/get_products.dart
+++ b/lib/graphql_operations/storefront/queries/get_products.dart
@@ -1,6 +1,6 @@
 /// Query to get products
 const String getProductsQuery = r'''
-query($cursor : String, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $cursor : String, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
   products(first: 250, after: $cursor, reverse: $reverse) {
     pageInfo {
       hasNextPage
@@ -12,6 +12,23 @@ query($cursor : String, $reverse: Boolean, $country: CountryCode)  @inContext(co
           id
           name
           values
+        }
+        metafields(identifiers: $metafields) {
+          id
+          type
+          key
+          namespace
+          value
+          description
+          reference {
+            ... on MediaImage {
+              image {
+                originalSrc
+                url
+                id
+              }
+            }
+          }
         }
         variants(first: 250) {
           edges {

--- a/lib/graphql_operations/storefront/queries/get_products_by_ids.dart
+++ b/lib/graphql_operations/storefront/queries/get_products_by_ids.dart
@@ -1,13 +1,30 @@
 /// Query to get products by ids
 const String getProductsByIdsQuery = r'''
-query($country: CountryCode, $ids : [ID!]!) @inContext(country: $country) {
+query($metafields: [HasMetafieldsIdentifier!]!, $country: CountryCode, $ids : [ID!]!) @inContext(country: $country) {
   nodes(ids: $ids) {
     ... on Product {
+      metafields(identifiers: $metafields) {
+        id
+        type
+        key
+        namespace
+        value
+        description
+        reference {
+          ... on MediaImage {
+            image {
+              originalSrc
+              url
+              id
+            }
+          }
+        }
+      }
     options(first: 50) {
             id
             name
             values
-            } 
+            }
       id
       handle
       collections(first: 250) {

--- a/lib/graphql_operations/storefront/queries/get_x_collections_and_n_products_sorted.dart
+++ b/lib/graphql_operations/storefront/queries/get_x_collections_and_n_products_sorted.dart
@@ -1,6 +1,6 @@
 /// Query to get x collections and n products sorted
 const String getXCollectionsAndNProductsSortedQuery = r'''
-query($cursor: String, $sortKey: CollectionSortKeys, $sortKeyProduct: ProductCollectionSortKeys, $reverse: Boolean, $x: Int, $n: Int, $country: CountryCode)  @inContext(country: $country){
+query($productMetafields: [HasMetafieldsIdentifier!]!, $collectonMetafields: [HasMetafieldsIdentifier!]!, $cursor: String, $sortKey: CollectionSortKeys, $sortKeyProduct: ProductCollectionSortKeys, $reverse: Boolean, $x: Int, $n: Int, $country: CountryCode)  @inContext(country: $country){
   collections(first: $x, after: $cursor, sortKey: $sortKey, reverse: $reverse) {
   pageInfo{
     hasNextPage
@@ -19,9 +19,43 @@ query($cursor: String, $sortKey: CollectionSortKeys, $sortKeyProduct: ProductCol
           id
           originalSrc
         }
+        metafields(identifiers: $collectionMetafields) {
+          id
+          type
+          key
+          namespace
+          value
+          description
+          reference {
+            ... on MediaImage {
+              image {
+                originalSrc
+                url
+                id
+              }
+            }
+          }
+        }
         products(first: $n, sortKey: $sortKeyProduct) {
           edges {
             node {
+              metafields(identifiers: $productMetafields) {
+                id
+                type
+                key
+                namespace
+                value
+                description
+                reference {
+                  ... on MediaImage {
+                    image {
+                      originalSrc
+                      url
+                      id
+                    }
+                  }
+                }
+              }
               variants(first: 250) {
                 edges {
                   node {

--- a/lib/graphql_operations/storefront/queries/get_x_products_after_cursor.dart
+++ b/lib/graphql_operations/storefront/queries/get_x_products_after_cursor.dart
@@ -1,6 +1,6 @@
 /// Query to get x products after cursor
 const String getXProductsAfterCursorQuery = r'''
-query($cursor : String, $x : Int, $reverse: Boolean, $sortKey: ProductSortKeys, $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $cursor : String, $x : Int, $reverse: Boolean, $sortKey: ProductSortKeys, $country: CountryCode)  @inContext(country: $country){
   products(first: $x, after: $cursor, sortKey: $sortKey, reverse: $reverse) {
     pageInfo {
       hasNextPage
@@ -12,7 +12,24 @@ query($cursor : String, $x : Int, $reverse: Boolean, $sortKey: ProductSortKeys, 
             id
             name
             values
-            } 
+            }
+        metafields(identifiers: $metafields) {
+          id
+          type
+          key
+          namespace
+          value
+          description
+          reference {
+            ... on MediaImage {
+              image {
+                originalSrc
+                url
+                id
+              }
+            }
+          }
+        }
         variants(first: 250) {
           edges {
             node {

--- a/lib/graphql_operations/storefront/queries/get_x_products_after_cursor_within_collection.dart
+++ b/lib/graphql_operations/storefront/queries/get_x_products_after_cursor_within_collection.dart
@@ -1,6 +1,6 @@
 /// Query to get x products after cursor within collection
 const String getXProductsAfterCursorWithinCollectionQuery = r'''
-query($id : ID!, $cursor : String, $limit : Int, $sortKey : ProductCollectionSortKeys, $reverse: Boolean, $filters: [ProductFilter!], $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $id : ID!, $cursor : String, $limit : Int, $sortKey : ProductCollectionSortKeys, $reverse: Boolean, $filters: [ProductFilter!], $country: CountryCode)  @inContext(country: $country){
   node(id: $id) {
     ... on Collection {
       id
@@ -22,7 +22,24 @@ query($id : ID!, $cursor : String, $limit : Int, $sortKey : ProductCollectionSor
             id
             name
             values
-            } 
+            }
+          metafields(identifiers: $metafields) {
+            id
+            type
+            key
+            namespace
+            value
+            description
+            reference {
+              ... on MediaImage {
+                image {
+                  originalSrc
+                  url
+                  id
+                }
+              }
+            }
+          }
             availableForSale
             collections(first: 1) {
               edges {

--- a/lib/graphql_operations/storefront/queries/get_x_products_on_query_after_cursor.dart
+++ b/lib/graphql_operations/storefront/queries/get_x_products_on_query_after_cursor.dart
@@ -1,14 +1,31 @@
 /// Query to get x products on query after cursor
 const String getXProductsOnQueryAfterCursorQuery = r'''
-query( $cursor: String, $limit : Int, $sortKey : ProductSortKeys, $query: String, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $cursor: String, $limit : Int, $sortKey : ProductSortKeys, $query: String, $reverse: Boolean, $country: CountryCode)  @inContext(country: $country){
   products(query: $query, first: $limit, after: $cursor, sortKey: $sortKey, reverse: $reverse) {
     edges {
       node {
-      options(first: 50) {
-            id
-            name
-            values
-            } 
+        options(first: 50) {
+          id
+          name
+          values
+        }
+        metafields(identifiers: $metafields) {
+          id
+          type
+          key
+          namespace
+          value
+          description
+          reference {
+            ... on MediaImage {
+              image {
+                originalSrc
+                url
+                id
+              }
+            }
+          }
+        }
         id
         handle
         availableForSale

--- a/lib/graphql_operations/storefront/queries/search_product.dart
+++ b/lib/graphql_operations/storefront/queries/search_product.dart
@@ -1,6 +1,6 @@
 /// Query search products
 const String getSearchedProducts = r'''
-query($query: String!, $cursor : String, $limit : Int, $sortKey : SearchSortKeys, $reverse: Boolean, $filters: [ProductFilter!], $country: CountryCode)  @inContext(country: $country){
+query($metafields: [HasMetafieldsIdentifier!]!, $query: String!, $cursor : String, $limit : Int, $sortKey : SearchSortKeys, $reverse: Boolean, $filters: [ProductFilter!], $country: CountryCode)  @inContext(country: $country){
   search(query: $query, first: $limit, sortKey: $sortKey, after: $cursor, reverse: $reverse, productFilters: $filters, types: PRODUCT){
     pageInfo {
       hasNextPage
@@ -13,7 +13,24 @@ query($query: String!, $cursor : String, $limit : Int, $sortKey : SearchSortKeys
             id
             name
             values
-          } 
+          }
+          metafields(identifiers: $metafields) {
+            id
+            type
+            key
+            namespace
+            value
+            description
+            reference {
+              ... on MediaImage {
+                image {
+                  originalSrc
+                  url
+                  id
+                }
+              }
+            }
+          }
       id
       handle
       collections(first: 250) {

--- a/lib/models/json_helper.dart
+++ b/lib/models/json_helper.dart
@@ -30,9 +30,7 @@ class JsonHelper {
       return [];
     }
 
-    return (json['edges'] as List)
-        .map((e) => LineItem.fromGraphJson(e))
-        .toList();
+    return (json['edges'] as List).map((e) => LineItem.fromGraphJson(e)).toList();
   }
 
   /// returns a amount from a json object

--- a/lib/models/src/address_autocomplete/address_details/address_details.dart
+++ b/lib/models/src/address_autocomplete/address_details/address_details.dart
@@ -24,6 +24,5 @@ class AddressDetails with _$AddressDetails {
   }) = _AddressDetails;
 
   /// A factory constructor for address details
-  factory AddressDetails.fromJson(Map<String, dynamic> json) =>
-      _$AddressDetailsFromJson(json);
+  factory AddressDetails.fromJson(Map<String, dynamic> json) => _$AddressDetailsFromJson(json);
 }

--- a/lib/models/src/address_autocomplete/address_prediction/address_prediction.dart
+++ b/lib/models/src/address_autocomplete/address_prediction/address_prediction.dart
@@ -16,6 +16,5 @@ class AddressPrediction with _$AddressPrediction {
   }) = _AddressPrediction;
 
   /// The address prediction from json
-  factory AddressPrediction.fromJson(Map<String, dynamic> json) =>
-      _$AddressPredictionFromJson(json);
+  factory AddressPrediction.fromJson(Map<String, dynamic> json) => _$AddressPredictionFromJson(json);
 }

--- a/lib/models/src/address_autocomplete/location_input/location_input.dart
+++ b/lib/models/src/address_autocomplete/location_input/location_input.dart
@@ -14,6 +14,5 @@ class LocationInput with _$LocationInput {
   }) = _LocationInput;
 
   /// The `LocationInput` from json
-  factory LocationInput.fromJson(Map<String, dynamic> json) =>
-      _$LocationInputFromJson(json);
+  factory LocationInput.fromJson(Map<String, dynamic> json) => _$LocationInputFromJson(json);
 }

--- a/lib/models/src/address_autocomplete/matched_substring/matched_substring.dart
+++ b/lib/models/src/address_autocomplete/matched_substring/matched_substring.dart
@@ -14,6 +14,5 @@ class MatchedSubstring with _$MatchedSubstring {
   }) = _MatchedSubstring;
 
   /// The matched substring from json
-  factory MatchedSubstring.fromJson(Map<String, dynamic> json) =>
-      _$MatchedSubstringFromJson(json);
+  factory MatchedSubstring.fromJson(Map<String, dynamic> json) => _$MatchedSubstringFromJson(json);
 }

--- a/lib/models/src/article/article.dart
+++ b/lib/models/src/article/article.dart
@@ -31,24 +31,19 @@ class Article with _$Article {
   }) = _Article;
 
   /// The article from json
-  factory Article.fromJson(Map<String, dynamic> json) =>
-      _$ArticleFromJson(json);
+  factory Article.fromJson(Map<String, dynamic> json) => _$ArticleFromJson(json);
 
   ///  The article from graph json
   factory Article.fromGraphJson(Map<String, dynamic> json) => Article(
-        author: AuthorV2.fromJson(
-            ((json['node'] ?? const {})['authorV2']) ?? const {}),
-        commentList:
-            _getCommentList((json['node'] ?? const {})['comments'] ?? const {}),
+        author: AuthorV2.fromJson(((json['node'] ?? const {})['authorV2']) ?? const {}),
+        commentList: _getCommentList((json['node'] ?? const {})['comments'] ?? const {}),
         content: (json['node'] ?? const {})['content'],
         contentHtml: (json['node'] ?? const {})['contentHtml'],
         excerpt: (json['node'] ?? const {})['excerpt'],
         excerptHtml: (json['node'] ?? const {})['excerptHtml'],
         handle: (json['node'] ?? const {})['handle'],
         id: (json['node'] ?? const {})['id'],
-        image: json['node']['image'] == null
-            ? null
-            : ShopifyImage.fromJson(json['node']['image']),
+        image: json['node']['image'] == null ? null : ShopifyImage.fromJson(json['node']['image']),
         publishedAt: (json['node'] ?? const {})['publishedAt'],
         tags: _getTagsList(json),
         title: (json['node'] ?? const {})['title'],
@@ -57,8 +52,7 @@ class Article with _$Article {
 
   static _getCommentList(Map<String, dynamic> json) {
     List<Comment> commentList = [];
-    json['edges']?.forEach((comment) =>
-        commentList.add(Comment.fromGraphJson(comment ?? const {})));
+    json['edges']?.forEach((comment) => commentList.add(Comment.fromGraphJson(comment ?? const {})));
     return commentList;
   }
 

--- a/lib/models/src/article/articles/articles.dart
+++ b/lib/models/src/article/articles/articles.dart
@@ -13,17 +13,14 @@ class Articles with _$Articles {
   factory Articles({required List<Article> articleList}) = _Articles;
 
   /// The `Articles` from json
-  factory Articles.fromJson(Map<String, dynamic> json) =>
-      _$ArticlesFromJson(json);
+  factory Articles.fromJson(Map<String, dynamic> json) => _$ArticlesFromJson(json);
 
   /// The `Articles` from graph json
-  factory Articles.fromGraphJson(Map<String, dynamic> json) =>
-      Articles(articleList: _getArticleList(json));
+  factory Articles.fromGraphJson(Map<String, dynamic> json) => Articles(articleList: _getArticleList(json));
 
   static _getArticleList(Map<String, dynamic> json) {
     List<Article> articleList = [];
-    json['edges']?.forEach((article) =>
-        articleList.add(Article.fromGraphJson(article ?? const {})));
+    json['edges']?.forEach((article) => articleList.add(Article.fromGraphJson(article ?? const {})));
     return articleList;
   }
 }

--- a/lib/models/src/article/author_v_2/author_v_2.dart
+++ b/lib/models/src/article/author_v_2/author_v_2.dart
@@ -8,14 +8,8 @@ part 'author_v_2.g.dart';
 /// The AuthorV2 class
 class AuthorV2 with _$AuthorV2 {
   /// The AuthorV2 constructor
-  factory AuthorV2(
-      {String? bio,
-      String? email,
-      String? firstName,
-      String? lastName,
-      String? name}) = _AuthorV2;
+  factory AuthorV2({String? bio, String? email, String? firstName, String? lastName, String? name}) = _AuthorV2;
 
   /// The AuthorV2 from json
-  factory AuthorV2.fromJson(Map<String, dynamic> json) =>
-      _$AuthorV2FromJson(json);
+  factory AuthorV2.fromJson(Map<String, dynamic> json) => _$AuthorV2FromJson(json);
 }

--- a/lib/models/src/article/comment/comment.dart
+++ b/lib/models/src/article/comment/comment.dart
@@ -19,8 +19,7 @@ class Comment with _$Comment {
   }) = _Comment;
 
   /// The Comment from json
-  factory Comment.fromJson(Map<String, dynamic> json) =>
-      _$CommentFromJson(json);
+  factory Comment.fromJson(Map<String, dynamic> json) => _$CommentFromJson(json);
 
   /// The Comment from graph json
   factory Comment.fromGraphJson(Map<String, dynamic> json) => Comment(

--- a/lib/models/src/blog/blogs/blogs.dart
+++ b/lib/models/src/blog/blogs/blogs.dart
@@ -16,13 +16,11 @@ class Blogs with _$Blogs {
   factory Blogs.fromJson(Map<String, dynamic> json) => _$BlogsFromJson(json);
 
   /// The Blogs from graph json
-  factory Blogs.fromGraphJson(Map<String, dynamic> json) =>
-      Blogs(blogList: _getBlogList(json));
+  factory Blogs.fromGraphJson(Map<String, dynamic> json) => Blogs(blogList: _getBlogList(json));
 
   static List<Blog> _getBlogList(Map<String, dynamic> json) {
     List<Blog> blogList = [];
-    json['edges']
-        ?.forEach((blog) => blogList.add(Blog.fromGraphJson(blog ?? const {})));
+    json['edges']?.forEach((blog) => blogList.add(Blog.fromGraphJson(blog ?? const {})));
     return blogList;
   }
 }

--- a/lib/models/src/cart/cart_buyer_identity/cart_buyer_identity.dart
+++ b/lib/models/src/cart/cart_buyer_identity/cart_buyer_identity.dart
@@ -24,6 +24,5 @@ class CartBuyerIdentity with _$CartBuyerIdentity {
   }) = _CartBuyerIdentity;
 
   /// cart buyer identity from json factory
-  factory CartBuyerIdentity.fromJson(Map<String, dynamic> json) =>
-      _$CartBuyerIdentityFromJson(json);
+  factory CartBuyerIdentity.fromJson(Map<String, dynamic> json) => _$CartBuyerIdentityFromJson(json);
 }

--- a/lib/models/src/cart/cart_cost/cart_cost.dart
+++ b/lib/models/src/cart/cart_cost/cart_cost.dart
@@ -24,6 +24,5 @@ class CartCost with _$CartCost {
   }) = _CartCost;
 
   /// cart cost from json
-  factory CartCost.fromJson(Map<String, dynamic> json) =>
-      _$CartCostFromJson(json);
+  factory CartCost.fromJson(Map<String, dynamic> json) => _$CartCostFromJson(json);
 }

--- a/lib/models/src/cart/cart_dicount_code/cart_discount_code.dart
+++ b/lib/models/src/cart/cart_dicount_code/cart_discount_code.dart
@@ -16,6 +16,5 @@ class CartDiscountCode with _$CartDiscountCode {
   }) = _CartDiscountCode;
 
   /// The CartDiscountCode from json
-  factory CartDiscountCode.fromJson(Map<String, dynamic> json) =>
-      _$CartDiscountCodeFromJson(json);
+  factory CartDiscountCode.fromJson(Map<String, dynamic> json) => _$CartDiscountCodeFromJson(json);
 }

--- a/lib/models/src/cart/cart_discount_allocation/cart_discount_allocation.dart
+++ b/lib/models/src/cart/cart_discount_allocation/cart_discount_allocation.dart
@@ -16,6 +16,5 @@ class CartDiscountAllocation with _$CartDiscountAllocation {
   }) = _CartDiscountAllocation;
 
   /// The cart discount allocation from json
-  factory CartDiscountAllocation.fromJson(Map<String, dynamic> json) =>
-      _$CartDiscountAllocationFromJson(json);
+  factory CartDiscountAllocation.fromJson(Map<String, dynamic> json) => _$CartDiscountAllocationFromJson(json);
 }

--- a/lib/models/src/cart/cart_preference/cart_delivery_coordinates_preference/cart_delivery_coordinates_preference.dart
+++ b/lib/models/src/cart/cart_preference/cart_delivery_coordinates_preference/cart_delivery_coordinates_preference.dart
@@ -6,8 +6,7 @@ part 'cart_delivery_coordinates_preference.g.dart';
 @freezed
 
 /// The cart delivery coordinates preference
-class CartDeliveryCoordinatesPreference
-    with _$CartDeliveryCoordinatesPreference {
+class CartDeliveryCoordinatesPreference with _$CartDeliveryCoordinatesPreference {
   const CartDeliveryCoordinatesPreference._();
 
   /// The cart delivery coordinates preference constructor
@@ -18,7 +17,6 @@ class CartDeliveryCoordinatesPreference
   }) = _CartDeliveryCoordinatesPreference;
 
   ///
-  factory CartDeliveryCoordinatesPreference.fromJson(
-          Map<String, dynamic> json) =>
+  factory CartDeliveryCoordinatesPreference.fromJson(Map<String, dynamic> json) =>
       _$CartDeliveryCoordinatesPreferenceFromJson(json);
 }

--- a/lib/models/src/cart/cart_preference/cart_delivery_preference/cart_delivery_preference.dart
+++ b/lib/models/src/cart/cart_preference/cart_delivery_preference/cart_delivery_preference.dart
@@ -18,6 +18,5 @@ class CartDeliveryPreference with _$CartDeliveryPreference {
   }) = _CartDeliveryPreference;
 
   /// The cart delivery preference from json
-  factory CartDeliveryPreference.fromJson(Map<String, dynamic> json) =>
-      _$CartDeliveryPreferenceFromJson(json);
+  factory CartDeliveryPreference.fromJson(Map<String, dynamic> json) => _$CartDeliveryPreferenceFromJson(json);
 }

--- a/lib/models/src/cart/cart_preference/cart_preference.dart
+++ b/lib/models/src/cart/cart_preference/cart_preference.dart
@@ -18,6 +18,5 @@ class CartPreference with _$CartPreference {
   }) = _CartPreference;
 
   /// The cart preference from json
-  factory CartPreference.fromJson(Map<String, dynamic> json) =>
-      _$CartPreferenceFromJson(json);
+  factory CartPreference.fromJson(Map<String, dynamic> json) => _$CartPreferenceFromJson(json);
 }

--- a/lib/models/src/cart/customer/customer.dart
+++ b/lib/models/src/cart/customer/customer.dart
@@ -24,6 +24,5 @@ class Customer with _$Customer {
   }) = _Customer;
 
   /// The cart customer from json
-  factory Customer.fromJson(Map<String, dynamic> json) =>
-      _$CustomerFromJson(json);
+  factory Customer.fromJson(Map<String, dynamic> json) => _$CustomerFromJson(json);
 }

--- a/lib/models/src/cart/inputs/cart_buyer_identity_input/cart_buyer_identity_input.dart
+++ b/lib/models/src/cart/inputs/cart_buyer_identity_input/cart_buyer_identity_input.dart
@@ -21,6 +21,5 @@ class CartBuyerIdentityInput with _$CartBuyerIdentityInput {
   }) = _CartBuyerIdentityInput;
 
   /// the cart buyer identity input from json factory
-  factory CartBuyerIdentityInput.fromJson(Map<String, dynamic> json) =>
-      _$CartBuyerIdentityInputFromJson(json);
+  factory CartBuyerIdentityInput.fromJson(Map<String, dynamic> json) => _$CartBuyerIdentityInputFromJson(json);
 }

--- a/lib/models/src/cart/inputs/cart_input/cart_input.dart
+++ b/lib/models/src/cart/inputs/cart_input/cart_input.dart
@@ -21,6 +21,5 @@ class CartInput with _$CartInput {
   }) = _CartInput;
 
   /// The cart input from json factory
-  factory CartInput.fromJson(Map<String, dynamic> json) =>
-      _$CartInputFromJson(json);
+  factory CartInput.fromJson(Map<String, dynamic> json) => _$CartInputFromJson(json);
 }

--- a/lib/models/src/cart/inputs/cart_line_input/cart_line_input.dart
+++ b/lib/models/src/cart/inputs/cart_line_input/cart_line_input.dart
@@ -17,6 +17,5 @@ class CartLineInput with _$CartLineInput {
   }) = _CartLineInput;
 
   /// The cart line input from json factory
-  factory CartLineInput.fromJson(Map<String, dynamic> json) =>
-      _$CartLineInputFromJson(json);
+  factory CartLineInput.fromJson(Map<String, dynamic> json) => _$CartLineInputFromJson(json);
 }

--- a/lib/models/src/cart/inputs/cart_line_update_input/cart_line_update_input.dart
+++ b/lib/models/src/cart/inputs/cart_line_update_input/cart_line_update_input.dart
@@ -18,6 +18,5 @@ class CartLineUpdateInput with _$CartLineUpdateInput {
   }) = _CartLine;
 
   /// The cart line input from json factory
-  factory CartLineUpdateInput.fromJson(Map<String, dynamic> json) =>
-      _$CartLineUpdateInputFromJson(json);
+  factory CartLineUpdateInput.fromJson(Map<String, dynamic> json) => _$CartLineUpdateInputFromJson(json);
 }

--- a/lib/models/src/cart/inputs/delivery_address_input/delivery_address_input.dart
+++ b/lib/models/src/cart/inputs/delivery_address_input/delivery_address_input.dart
@@ -23,6 +23,5 @@ class DeliveryAddressInput with _$DeliveryAddressInput {
   }) = _DeliveryAddressInput;
 
   /// The delivery address input from json factory
-  factory DeliveryAddressInput.fromJson(Map<String, dynamic> json) =>
-      _$DeliveryAddressInputFromJson(json);
+  factory DeliveryAddressInput.fromJson(Map<String, dynamic> json) => _$DeliveryAddressInputFromJson(json);
 }

--- a/lib/models/src/cart/inputs/mailing_address_input/mailing_address_input.dart
+++ b/lib/models/src/cart/inputs/mailing_address_input/mailing_address_input.dart
@@ -24,6 +24,5 @@ class MailingAddressInput with _$MailingAddressInput {
   }) = _MailingAddressInput;
 
   /// The mailing address input from json factory
-  factory MailingAddressInput.fromJson(Map<String, dynamic> json) =>
-      _$MailingAddressInputFromJson(json);
+  factory MailingAddressInput.fromJson(Map<String, dynamic> json) => _$MailingAddressInputFromJson(json);
 }

--- a/lib/models/src/cart/lines/cart_line_cost/cart_line_cost.dart
+++ b/lib/models/src/cart/lines/cart_line_cost/cart_line_cost.dart
@@ -19,6 +19,5 @@ class CartLineCost with _$CartLineCost {
   }) = _CartLineCost;
 
   /// the cart line cost from json
-  factory CartLineCost.fromJson(Map<String, dynamic> json) =>
-      _$CartLineCostFromJson(json);
+  factory CartLineCost.fromJson(Map<String, dynamic> json) => _$CartLineCostFromJson(json);
 }

--- a/lib/models/src/cart/lines/line/line.dart
+++ b/lib/models/src/cart/lines/line/line.dart
@@ -37,16 +37,11 @@ class Line with _$Line {
     return Line(
       id: nodeJson['id'],
       quantity: nodeJson['quantity'],
-      cost: nodeJson['cost'] != null
-          ? CartLineCost.fromJson(nodeJson['cost'])
-          : null,
+      cost: nodeJson['cost'] != null ? CartLineCost.fromJson(nodeJson['cost']) : null,
       merchandise: merchandise,
       variantId: merchandise?.id,
-      discountAllocations: (nodeJson['discountAllocations'] != null &&
-              nodeJson['discountAllocations'] is List)
-          ? (nodeJson['discountAllocations'] as List)
-              .map((e) => CartDiscountAllocation.fromJson(e))
-              .toList()
+      discountAllocations: (nodeJson['discountAllocations'] != null && nodeJson['discountAllocations'] is List)
+          ? (nodeJson['discountAllocations'] as List).map((e) => CartDiscountAllocation.fromJson(e)).toList()
           : null,
       sellingPlanAllocation: nodeJson['sellingPlanAllocation'] != null
           ? SellingPlanAllocation.fromJson(nodeJson['sellingPlanAllocation'])

--- a/lib/models/src/checkout/applied_gift_cards/applied_gift_cards.dart
+++ b/lib/models/src/checkout/applied_gift_cards/applied_gift_cards.dart
@@ -11,12 +11,9 @@ class AppliedGiftCards with _$AppliedGiftCards {
   const AppliedGiftCards._();
 
   /// The applied gift cards constructor
-  factory AppliedGiftCards(
-      {required PriceV2 amountUsedV2,
-      required PriceV2 balanceV2,
-      required String id}) = _AppliedGiftCards;
+  factory AppliedGiftCards({required PriceV2 amountUsedV2, required PriceV2 balanceV2, required String id}) =
+      _AppliedGiftCards;
 
   /// The applied gift cards from json
-  factory AppliedGiftCards.fromJson(Map<String, dynamic> json) =>
-      _$AppliedGiftCardsFromJson(json);
+  factory AppliedGiftCards.fromJson(Map<String, dynamic> json) => _$AppliedGiftCardsFromJson(json);
 }

--- a/lib/models/src/checkout/attribute/attribute.dart
+++ b/lib/models/src/checkout/attribute/attribute.dart
@@ -16,6 +16,5 @@ class Attribute with _$Attribute {
   }) = _Attribute;
 
   /// The Attribute from json
-  factory Attribute.fromJson(Map<String, dynamic> json) =>
-      _$AttributeFromJson(json);
+  factory Attribute.fromJson(Map<String, dynamic> json) => _$AttributeFromJson(json);
 }

--- a/lib/models/src/checkout/available_shipping_rates/available_shipping_rates.dart
+++ b/lib/models/src/checkout/available_shipping_rates/available_shipping_rates.dart
@@ -11,11 +11,9 @@ class AvailableShippingRates with _$AvailableShippingRates {
   const AvailableShippingRates._();
 
   /// The available shipping rates constructor
-  factory AvailableShippingRates(
-      {required bool ready,
-      required List<ShippingRates>? shippingRates}) = _AvailableShippingRates;
+  factory AvailableShippingRates({required bool ready, required List<ShippingRates>? shippingRates}) =
+      _AvailableShippingRates;
 
   /// The available shipping rates from json
-  factory AvailableShippingRates.fromJson(Map<String, dynamic> json) =>
-      _$AvailableShippingRatesFromJson(json);
+  factory AvailableShippingRates.fromJson(Map<String, dynamic> json) => _$AvailableShippingRatesFromJson(json);
 }

--- a/lib/models/src/checkout/checkout.dart
+++ b/lib/models/src/checkout/checkout.dart
@@ -48,6 +48,5 @@ class Checkout with _$Checkout {
   }) = _Checkout;
 
   /// The checkout from json
-  factory Checkout.fromJson(Map<String, dynamic> json) =>
-      _$CheckoutFromJson(json);
+  factory Checkout.fromJson(Map<String, dynamic> json) => _$CheckoutFromJson(json);
 }

--- a/lib/models/src/checkout/line_item/line_item.dart
+++ b/lib/models/src/checkout/line_item/line_item.dart
@@ -30,22 +30,15 @@ class LineItem with _$LineItem {
     return LineItem(
       id: nodeJson['id'],
       quantity: nodeJson['quantity'],
-      variant: nodeJson['variant'] != null
-          ? ProductVariantCheckout.fromJson(nodeJson['variant'])
-          : null,
+      variant: nodeJson['variant'] != null ? ProductVariantCheckout.fromJson(nodeJson['variant']) : null,
       title: nodeJson['title'],
       discountAllocations: nodeJson['discountAllocations'] == null
           ? []
-          : (nodeJson['discountAllocations'] as List)
-              .map((e) => DiscountAllocations.fromJson(e))
-              .toList(),
-      variantId: nodeJson['variant'] != null
-          ? ProductVariantCheckout.fromJson(nodeJson['variant']).id
-          : null,
+          : (nodeJson['discountAllocations'] as List).map((e) => DiscountAllocations.fromJson(e)).toList(),
+      variantId: nodeJson['variant'] != null ? ProductVariantCheckout.fromJson(nodeJson['variant']).id : null,
     );
   }
 
   /// The line item from json
-  factory LineItem.fromJson(Map<String, dynamic> json) =>
-      _$LineItemFromJson(json);
+  factory LineItem.fromJson(Map<String, dynamic> json) => _$LineItemFromJson(json);
 }

--- a/lib/models/src/checkout/line_items/line_items.dart
+++ b/lib/models/src/checkout/line_items/line_items.dart
@@ -12,6 +12,5 @@ class LineItems with _$LineItems {
   factory LineItems({required List<LineItem> lineItemList}) = _LineItems;
 
   /// The line items from json factory
-  factory LineItems.fromJson(Map<String, dynamic> json) =>
-      _$LineItemsFromJson(json);
+  factory LineItems.fromJson(Map<String, dynamic> json) => _$LineItemsFromJson(json);
 }

--- a/lib/models/src/checkout/mailing_address/mailing_address.dart
+++ b/lib/models/src/checkout/mailing_address/mailing_address.dart
@@ -29,6 +29,5 @@ class MailingAddress with _$MailingAddress {
   }) = _MailingAddress;
 
   /// The mailing address from json
-  factory MailingAddress.fromJson(Map<String, dynamic> json) =>
-      _$MailingAddressFromJson(json);
+  factory MailingAddress.fromJson(Map<String, dynamic> json) => _$MailingAddressFromJson(json);
 }

--- a/lib/models/src/checkout/product_variant_checkout/product_variant_checkout.dart
+++ b/lib/models/src/checkout/product_variant_checkout/product_variant_checkout.dart
@@ -32,6 +32,5 @@ class ProductVariantCheckout with _$ProductVariantCheckout {
   }) = _ProductVariantCheckout;
 
   /// The product variant checkout from json
-  factory ProductVariantCheckout.fromJson(Map<String, dynamic> json) =>
-      _$ProductVariantCheckoutFromJson(json);
+  factory ProductVariantCheckout.fromJson(Map<String, dynamic> json) => _$ProductVariantCheckoutFromJson(json);
 }

--- a/lib/models/src/checkout/shipping_rates/shipping_rates.dart
+++ b/lib/models/src/checkout/shipping_rates/shipping_rates.dart
@@ -11,12 +11,8 @@ class ShippingRates with _$ShippingRates {
   const ShippingRates._();
 
   /// The shipping rates constructor
-  factory ShippingRates(
-      {required String handle,
-      required String title,
-      required PriceV2 priceV2}) = _ShippingRates;
+  factory ShippingRates({required String handle, required String title, required PriceV2 priceV2}) = _ShippingRates;
 
   /// The shipping rates from json
-  factory ShippingRates.fromJson(Map<String, dynamic> json) =>
-      _$ShippingRatesFromJson(json);
+  factory ShippingRates.fromJson(Map<String, dynamic> json) => _$ShippingRatesFromJson(json);
 }

--- a/lib/models/src/checkout/tokanized_checkout/tokanized_checkout.dart
+++ b/lib/models/src/checkout/tokanized_checkout/tokanized_checkout.dart
@@ -20,13 +20,11 @@ class TokanizedCheckout with _$TokanizedCheckout {
     required bool ready,
     String? nextActionUrl,
     String? errorMessage,
-    @JsonKey(name: 'checkout', fromJson: _checkoutIdFromJson)
-    String? checkoutId,
+    @JsonKey(name: 'checkout', fromJson: _checkoutIdFromJson) String? checkoutId,
   }) = _TokanizedCheckout;
 
   /// The tokanized checkout from json
-  factory TokanizedCheckout.fromJson(Map<String, dynamic> json) =>
-      _$TokanizedCheckoutFromJson(json);
+  factory TokanizedCheckout.fromJson(Map<String, dynamic> json) => _$TokanizedCheckoutFromJson(json);
 }
 
 String? _checkoutIdFromJson(Map<String, dynamic> json) {

--- a/lib/models/src/collection/collection.freezed.dart
+++ b/lib/models/src/collection/collection.freezed.dart
@@ -23,6 +23,7 @@ mixin _$Collection {
   String get title => throw _privateConstructorUsedError;
   String get id => throw _privateConstructorUsedError;
   Products get products => throw _privateConstructorUsedError;
+  List<Metafield> get metafields => throw _privateConstructorUsedError;
   String? get cursor => throw _privateConstructorUsedError;
   String? get description => throw _privateConstructorUsedError;
   String? get descriptionHtml => throw _privateConstructorUsedError;
@@ -50,6 +51,7 @@ abstract class $CollectionCopyWith<$Res> {
       {String title,
       String id,
       Products products,
+      List<Metafield> metafields,
       String? cursor,
       String? description,
       String? descriptionHtml,
@@ -79,6 +81,7 @@ class _$CollectionCopyWithImpl<$Res, $Val extends Collection>
     Object? title = null,
     Object? id = null,
     Object? products = null,
+    Object? metafields = null,
     Object? cursor = freezed,
     Object? description = freezed,
     Object? descriptionHtml = freezed,
@@ -99,6 +102,10 @@ class _$CollectionCopyWithImpl<$Res, $Val extends Collection>
           ? _value.products
           : products // ignore: cast_nullable_to_non_nullable
               as Products,
+      metafields: null == metafields
+          ? _value.metafields
+          : metafields // ignore: cast_nullable_to_non_nullable
+              as List<Metafield>,
       cursor: freezed == cursor
           ? _value.cursor
           : cursor // ignore: cast_nullable_to_non_nullable
@@ -163,6 +170,7 @@ abstract class _$$CollectionImplCopyWith<$Res>
       {String title,
       String id,
       Products products,
+      List<Metafield> metafields,
       String? cursor,
       String? description,
       String? descriptionHtml,
@@ -192,6 +200,7 @@ class __$$CollectionImplCopyWithImpl<$Res>
     Object? title = null,
     Object? id = null,
     Object? products = null,
+    Object? metafields = null,
     Object? cursor = freezed,
     Object? description = freezed,
     Object? descriptionHtml = freezed,
@@ -212,6 +221,10 @@ class __$$CollectionImplCopyWithImpl<$Res>
           ? _value.products
           : products // ignore: cast_nullable_to_non_nullable
               as Products,
+      metafields: null == metafields
+          ? _value._metafields
+          : metafields // ignore: cast_nullable_to_non_nullable
+              as List<Metafield>,
       cursor: freezed == cursor
           ? _value.cursor
           : cursor // ignore: cast_nullable_to_non_nullable
@@ -247,13 +260,15 @@ class _$CollectionImpl extends _Collection {
       {required this.title,
       required this.id,
       required this.products,
+      required final List<Metafield> metafields,
       this.cursor,
       this.description,
       this.descriptionHtml,
       this.handle,
       this.updatedAt,
       this.image})
-      : super._();
+      : _metafields = metafields,
+        super._();
 
   factory _$CollectionImpl.fromJson(Map<String, dynamic> json) =>
       _$$CollectionImplFromJson(json);
@@ -264,6 +279,14 @@ class _$CollectionImpl extends _Collection {
   final String id;
   @override
   final Products products;
+  final List<Metafield> _metafields;
+  @override
+  List<Metafield> get metafields {
+    if (_metafields is EqualUnmodifiableListView) return _metafields;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_metafields);
+  }
+
   @override
   final String? cursor;
   @override
@@ -279,7 +302,7 @@ class _$CollectionImpl extends _Collection {
 
   @override
   String toString() {
-    return 'Collection(title: $title, id: $id, products: $products, cursor: $cursor, description: $description, descriptionHtml: $descriptionHtml, handle: $handle, updatedAt: $updatedAt, image: $image)';
+    return 'Collection(title: $title, id: $id, products: $products, metafields: $metafields, cursor: $cursor, description: $description, descriptionHtml: $descriptionHtml, handle: $handle, updatedAt: $updatedAt, image: $image)';
   }
 
   @override
@@ -291,6 +314,8 @@ class _$CollectionImpl extends _Collection {
             (identical(other.id, id) || other.id == id) &&
             (identical(other.products, products) ||
                 other.products == products) &&
+            const DeepCollectionEquality()
+                .equals(other._metafields, _metafields) &&
             (identical(other.cursor, cursor) || other.cursor == cursor) &&
             (identical(other.description, description) ||
                 other.description == description) &&
@@ -304,8 +329,18 @@ class _$CollectionImpl extends _Collection {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, title, id, products, cursor,
-      description, descriptionHtml, handle, updatedAt, image);
+  int get hashCode => Object.hash(
+      runtimeType,
+      title,
+      id,
+      products,
+      const DeepCollectionEquality().hash(_metafields),
+      cursor,
+      description,
+      descriptionHtml,
+      handle,
+      updatedAt,
+      image);
 
   /// Create a copy of Collection
   /// with the given fields replaced by the non-null parameter values.
@@ -328,6 +363,7 @@ abstract class _Collection extends Collection {
       {required final String title,
       required final String id,
       required final Products products,
+      required final List<Metafield> metafields,
       final String? cursor,
       final String? description,
       final String? descriptionHtml,
@@ -345,6 +381,8 @@ abstract class _Collection extends Collection {
   String get id;
   @override
   Products get products;
+  @override
+  List<Metafield> get metafields;
   @override
   String? get cursor;
   @override

--- a/lib/models/src/collection/collection.g.dart
+++ b/lib/models/src/collection/collection.g.dart
@@ -11,6 +11,9 @@ _$CollectionImpl _$$CollectionImplFromJson(Map<String, dynamic> json) =>
       title: json['title'] as String,
       id: json['id'] as String,
       products: Products.fromJson(json['products'] as Map<String, dynamic>),
+      metafields: (json['metafields'] as List<dynamic>)
+          .map((e) => Metafield.fromJson(e as Map<String, dynamic>))
+          .toList(),
       cursor: json['cursor'] as String?,
       description: json['description'] as String?,
       descriptionHtml: json['descriptionHtml'] as String?,
@@ -26,6 +29,7 @@ Map<String, dynamic> _$$CollectionImplToJson(_$CollectionImpl instance) =>
       'title': instance.title,
       'id': instance.id,
       'products': instance.products,
+      'metafields': instance.metafields,
       'cursor': instance.cursor,
       'description': instance.description,
       'descriptionHtml': instance.descriptionHtml,

--- a/lib/models/src/collection/collections/collections.dart
+++ b/lib/models/src/collection/collections/collections.dart
@@ -10,13 +10,10 @@ part 'collections.g.dart';
 /// The Collections class
 class Collections with _$Collections {
   /// The Collections constructor
-  factory Collections(
-      {required List<Collection> collectionList,
-      required bool hasNextPage}) = _Collections;
+  factory Collections({required List<Collection> collectionList, required bool hasNextPage}) = _Collections;
 
   /// The Collections from json
-  factory Collections.fromJson(Map<String, dynamic> json) =>
-      _$CollectionsFromJson(json);
+  factory Collections.fromJson(Map<String, dynamic> json) => _$CollectionsFromJson(json);
 
   /// The Collections from graph json
   factory Collections.fromGraphJson(Map<String, dynamic> json) => Collections(
@@ -26,8 +23,7 @@ class Collections with _$Collections {
 
   static List<Collection> _getCollectionList(Map<String, dynamic> json) {
     List<Collection> collectionList = [];
-    json['edges']?.forEach(
-        (e) => collectionList.add(Collection.fromGraphJson(e ?? const {})));
+    json['edges']?.forEach((e) => collectionList.add(Collection.fromGraphJson(e ?? const {})));
     return collectionList;
   }
 }

--- a/lib/models/src/localization/country/country.dart
+++ b/lib/models/src/localization/country/country.dart
@@ -21,6 +21,5 @@ class Country with _$Country {
   }) = _Country;
 
   /// The country from json factory
-  factory Country.fromJson(Map<String, dynamic> json) =>
-      _$CountryFromJson(json);
+  factory Country.fromJson(Map<String, dynamic> json) => _$CountryFromJson(json);
 }

--- a/lib/models/src/localization/currency/currency.dart
+++ b/lib/models/src/localization/currency/currency.dart
@@ -15,6 +15,5 @@ class Currency with _$Currency {
   }) = _Currency;
 
   /// The Currency from json
-  factory Currency.fromJson(Map<String, dynamic> json) =>
-      _$CurrencyFromJson(json);
+  factory Currency.fromJson(Map<String, dynamic> json) => _$CurrencyFromJson(json);
 }

--- a/lib/models/src/localization/language/language.dart
+++ b/lib/models/src/localization/language/language.dart
@@ -15,6 +15,5 @@ class Language with _$Language {
   }) = _Language;
 
   /// The Language from json
-  factory Language.fromJson(Map<String, dynamic> json) =>
-      _$LanguageFromJson(json);
+  factory Language.fromJson(Map<String, dynamic> json) => _$LanguageFromJson(json);
 }

--- a/lib/models/src/localization/localization.dart
+++ b/lib/models/src/localization/localization.dart
@@ -21,6 +21,5 @@ class Localization with _$Localization {
   }) = _Localization;
 
   /// The localization object from json
-  factory Localization.fromJson(Map<String, dynamic> json) =>
-      _$LocalizationFromJson(json);
+  factory Localization.fromJson(Map<String, dynamic> json) => _$LocalizationFromJson(json);
 }

--- a/lib/models/src/order/discount_allocations/discount_allocations.dart
+++ b/lib/models/src/order/discount_allocations/discount_allocations.dart
@@ -11,10 +11,8 @@ class DiscountAllocations with _$DiscountAllocations {
   const DiscountAllocations._();
 
   /// The discount allocations constructor
-  factory DiscountAllocations({required PriceV2? allocatedAmount}) =
-      _DiscountAllocations;
+  factory DiscountAllocations({required PriceV2? allocatedAmount}) = _DiscountAllocations;
 
   /// The discount allocations from json
-  factory DiscountAllocations.fromJson(Map<String, dynamic> json) =>
-      _$DiscountAllocationsFromJson(json);
+  factory DiscountAllocations.fromJson(Map<String, dynamic> json) => _$DiscountAllocationsFromJson(json);
 }

--- a/lib/models/src/order/line_item_order/line_item_order.dart
+++ b/lib/models/src/order/line_item_order/line_item_order.dart
@@ -27,31 +27,25 @@ class LineItemOrder with _$LineItemOrder {
   String? get productId => variant?.product?.id;
 
   /// The line item order from json
-  factory LineItemOrder.fromJson(Map<String, dynamic> json) =>
-      _$LineItemOrderFromJson(json);
+  factory LineItemOrder.fromJson(Map<String, dynamic> json) => _$LineItemOrderFromJson(json);
 
   /// The line item order from json
-  factory LineItemOrder.fromGraphJson(Map<String, dynamic> json) =>
-      LineItemOrder(
+  factory LineItemOrder.fromGraphJson(Map<String, dynamic> json) => LineItemOrder(
         currentQuantity: (json['node'] ?? const {})['currentQuantity'],
         discountAllocations: _getDiscountAllocationsList(json),
-        discountedTotalPrice: PriceV2.fromJson(
-            (json['node'] ?? const {})['discountedTotalPrice']),
-        originalTotalPrice:
-            PriceV2.fromJson((json['node'] ?? const {})['originalTotalPrice']),
+        discountedTotalPrice: PriceV2.fromJson((json['node'] ?? const {})['discountedTotalPrice']),
+        originalTotalPrice: PriceV2.fromJson((json['node'] ?? const {})['originalTotalPrice']),
         quantity: (json['node'] ?? const {})['quantity'],
         title: (json['node'] ?? const {})['title'],
-        variant: json['node']['variant'] == null
-            ? null
-            : ProductVariantCheckout.fromJson(json['node']['variant']),
+        variant: json['node']['variant'] == null ? null : ProductVariantCheckout.fromJson(json['node']['variant']),
         // variant: ProductVariantCheckout.fromJson(
         //     (json['node'] ?? const {})['variant'] ?? const {})
       );
 
   static _getDiscountAllocationsList(Map<String, dynamic> json) {
     List<DiscountAllocations> discountList = [];
-    (json['node'] ?? const {})['discountAllocations']?.forEach(
-        (discount) => discountList.add(DiscountAllocations.fromJson(discount)));
+    (json['node'] ?? const {})['discountAllocations']
+        ?.forEach((discount) => discountList.add(DiscountAllocations.fromJson(discount)));
     return discountList;
   }
 }

--- a/lib/models/src/order/line_items_order/line_items_order.dart
+++ b/lib/models/src/order/line_items_order/line_items_order.dart
@@ -9,12 +9,10 @@ part 'line_items_order.g.dart';
 /// The line items order
 class LineItemsOrder with _$LineItemsOrder {
   /// The line items order constructor
-  factory LineItemsOrder({required List<LineItemOrder> lineItemOrderList}) =
-      _LineItemsOrder;
+  factory LineItemsOrder({required List<LineItemOrder> lineItemOrderList}) = _LineItemsOrder;
 
   /// The line items order from json factory
-  factory LineItemsOrder.fromJson(Map<String, dynamic> json) =>
-      _$LineItemsOrderFromJson(json);
+  factory LineItemsOrder.fromJson(Map<String, dynamic> json) => _$LineItemsOrderFromJson(json);
 
   /// The line items order from graph json factory
   factory LineItemsOrder.fromGraphJson(Map<String, dynamic> json) =>
@@ -23,8 +21,7 @@ class LineItemsOrder with _$LineItemsOrder {
   static _getLineItemOrderList(Map<String, dynamic> json) {
     List<LineItemOrder> lineItemListOrder = [];
     if (json.containsKey('edges')) {
-      json['edges'].forEach((lineItemOrder) =>
-          lineItemListOrder.add(LineItemOrder.fromGraphJson(lineItemOrder)));
+      json['edges'].forEach((lineItemOrder) => lineItemListOrder.add(LineItemOrder.fromGraphJson(lineItemOrder)));
     }
     return lineItemListOrder;
   }

--- a/lib/models/src/order/order.dart
+++ b/lib/models/src/order/order.dart
@@ -54,18 +54,15 @@ class Order with _$Order {
         processedAt: json['node']['processedAt'],
         financialStatus: json['node']['financialStatus'],
         fulfillmentStatus: json['node']['fulfillmentStatus'],
-        shippingAddress: json['node']['shippingAddress'] == null
-            ? null
-            : ShippingAddress.fromJson(json['node']['shippingAddress']),
-        billingAddress: json['node']['billingAddress'] == null
-            ? null
-            : ShippingAddress.fromJson(json['node']['billingAddress']),
+        shippingAddress:
+            json['node']['shippingAddress'] == null ? null : ShippingAddress.fromJson(json['node']['shippingAddress']),
+        billingAddress:
+            json['node']['billingAddress'] == null ? null : ShippingAddress.fromJson(json['node']['billingAddress']),
         statusUrl: json['node']['statusUrl'],
         subtotalPriceV2: PriceV2.fromJson(json['node']['subtotalPriceV2']),
         totalPriceV2: PriceV2.fromJson(json['node']['totalPriceV2']),
         totalRefundedV2: PriceV2.fromJson(json['node']['totalRefundedV2']),
-        totalShippingPriceV2:
-            PriceV2.fromJson(json['node']['totalShippingPriceV2']),
+        totalShippingPriceV2: PriceV2.fromJson(json['node']['totalShippingPriceV2']),
         totalTaxV2: PriceV2.fromJson(json['node']['totalTaxV2']),
         cursor: json['cursor'],
         canceledAt: json['node']['canceledAt'],

--- a/lib/models/src/order/orders/orders.dart
+++ b/lib/models/src/order/orders/orders.dart
@@ -10,8 +10,7 @@ part 'orders.g.dart';
 /// The Orders class
 class Orders with _$Orders {
   /// The Orders constructor
-  factory Orders({required List<Order> orderList, required bool hasNextPage}) =
-      _Orders;
+  factory Orders({required List<Order> orderList, required bool hasNextPage}) = _Orders;
 
   /// The Orders from json
   factory Orders.fromJson(Map<String, dynamic> json) => _$OrdersFromJson(json);
@@ -25,8 +24,7 @@ class Orders with _$Orders {
   static List<Order> _getOrderList(Map<String, dynamic> json) {
     List<Order> orderList = [];
     if (json.containsKey('edges')) {
-      json['edges']
-          .forEach((e) => orderList.add(Order.fromGraphJson(e ?? const {})));
+      json['edges'].forEach((e) => orderList.add(Order.fromGraphJson(e ?? const {})));
     }
     return orderList;
   }

--- a/lib/models/src/order/shipping_address/shipping_address.dart
+++ b/lib/models/src/order/shipping_address/shipping_address.dart
@@ -28,6 +28,5 @@ class ShippingAddress with _$ShippingAddress {
   }) = _ShippingAddress;
 
   /// the shipping address from json
-  factory ShippingAddress.fromJson(Map<String, dynamic> json) =>
-      _$ShippingAddressFromJson(json);
+  factory ShippingAddress.fromJson(Map<String, dynamic> json) => _$ShippingAddressFromJson(json);
 }

--- a/lib/models/src/order/successful_fulfillment/successful_fulfilment_tracking_info/successful_fulfilment_tracking_info.dart
+++ b/lib/models/src/order/successful_fulfillment/successful_fulfilment_tracking_info/successful_fulfilment_tracking_info.dart
@@ -6,8 +6,7 @@ part 'successful_fulfilment_tracking_info.g.dart';
 @freezed
 
 ///
-class SuccessfulFullfilmentTrackingInfo
-    with _$SuccessfulFullfilmentTrackingInfo {
+class SuccessfulFullfilmentTrackingInfo with _$SuccessfulFullfilmentTrackingInfo {
   const SuccessfulFullfilmentTrackingInfo._();
 
   /// the successful fullfilment tracking info
@@ -26,7 +25,6 @@ class SuccessfulFullfilmentTrackingInfo
       );
 
   /// the successful fullfilment tracking info from json
-  factory SuccessfulFullfilmentTrackingInfo.fromJson(
-          Map<String, dynamic> json) =>
+  factory SuccessfulFullfilmentTrackingInfo.fromJson(Map<String, dynamic> json) =>
       _$SuccessfulFullfilmentTrackingInfoFromJson(json);
 }

--- a/lib/models/src/order/successful_fulfillment/successful_fullfilment.dart
+++ b/lib/models/src/order/successful_fulfillment/successful_fullfilment.dart
@@ -17,15 +17,13 @@ class SuccessfulFullfilment with _$SuccessfulFullfilment {
   }) = _SuccessfulFullfilment;
 
   /// The successful fullfilment from graph json factory
-  factory SuccessfulFullfilment.fromGraphJson(Map<String, dynamic> json) =>
-      SuccessfulFullfilment(
+  factory SuccessfulFullfilment.fromGraphJson(Map<String, dynamic> json) => SuccessfulFullfilment(
         trackingCompany: json['trackingCompany'],
         trackingInfo: _getTrackingInfoList(json['trackingInfo'] ?? []),
       );
 
   /// The successful fullfilment from json factory
-  factory SuccessfulFullfilment.fromJson(Map<String, dynamic> json) =>
-      _$SuccessfulFullfilmentFromJson(json);
+  factory SuccessfulFullfilment.fromJson(Map<String, dynamic> json) => _$SuccessfulFullfilmentFromJson(json);
 
   static _getTrackingInfoList(List<dynamic> data) {
     List<SuccessfulFullfilmentTrackingInfo> list = [];

--- a/lib/models/src/page/pages/pages.dart
+++ b/lib/models/src/page/pages/pages.dart
@@ -16,13 +16,11 @@ class Pages with _$Pages {
   factory Pages.fromJson(Map<String, dynamic> json) => _$PagesFromJson(json);
 
   ///
-  factory Pages.fromGraphJson(Map<String, dynamic> json) =>
-      Pages(pageList: _getPageList(json));
+  factory Pages.fromGraphJson(Map<String, dynamic> json) => Pages(pageList: _getPageList(json));
 
   static List<Page> _getPageList(Map<String, dynamic> json) {
     List<Page> pageList = [];
-    json['edges']
-        ?.forEach((blog) => pageList.add(Page.fromGraphJson(blog ?? const {})));
+    json['edges']?.forEach((blog) => pageList.add(Page.fromGraphJson(blog ?? const {})));
     return pageList;
   }
 }

--- a/lib/models/src/product/associated_collections/associated_collections.dart
+++ b/lib/models/src/product/associated_collections/associated_collections.dart
@@ -20,8 +20,7 @@ class AssociatedCollections with _$AssociatedCollections {
   }) = _AssociatedCollections;
 
   /// The AssociatedCollections from graphjson
-  factory AssociatedCollections.fromGraphJson(Map<String, dynamic> json) =>
-      AssociatedCollections(
+  factory AssociatedCollections.fromGraphJson(Map<String, dynamic> json) => AssociatedCollections(
         description: (json['node'] ?? const {})['description'],
         descriptionHtml: (json['node'] ?? const {})['descriptionHtml'],
         id: (json['node'] ?? const {})['id'],
@@ -31,6 +30,5 @@ class AssociatedCollections with _$AssociatedCollections {
       );
 
   /// The AssociatedCollections from json
-  factory AssociatedCollections.fromJson(Map<String, dynamic> json) =>
-      _$AssociatedCollectionsFromJson(json);
+  factory AssociatedCollections.fromJson(Map<String, dynamic> json) => _$AssociatedCollectionsFromJson(json);
 }

--- a/lib/models/src/product/metafield/metafield.dart
+++ b/lib/models/src/product/metafield/metafield.dart
@@ -16,20 +16,21 @@ class Metafield with _$Metafield {
     required String key,
     required String value,
     required String type,
-    @Default('') String description,
+    String? description,
+    Map<String, dynamic>? reference,
   }) = _Metafield;
 
   /// The Metafield from graphjson
   factory Metafield.fromGraphJson(Map<String, dynamic> json) => Metafield(
-        id: (json['node'] ?? const {})['id'],
-        key: (json['node'] ?? const {})['key'],
-        namespace: (json['node'] ?? const {})['namespace'],
-        type: (json['node'] ?? const {})['type'],
-        value: (json['node'] ?? const {})['value'],
-        description: (json['node'] ?? const {})['description'],
+        id: (json.containsKey('id') == true) ? json['id'] : '',
+        key: (json.containsKey('key') == true) ? json['key'] : '',
+        namespace: (json.containsKey('namespace') == true) ? json['namespace'] : '',
+        type: (json.containsKey('type') == true) ? json['type'] : '',
+        value: (json.containsKey('value') == true) ? json['value'] : '',
+        description: (json.containsKey('description') == true) ? json['description'] : null,
+        reference: (json.containsKey('reference') == true) ? json['reference'] : null,
       );
 
   /// The Metafield from json
-  factory Metafield.fromJson(Map<String, dynamic> json) =>
-      _$MetafieldFromJson(json);
+  factory Metafield.fromJson(Map<String, dynamic> json) => _$MetafieldFromJson(json);
 }

--- a/lib/models/src/product/metafield/metafield.freezed.dart
+++ b/lib/models/src/product/metafield/metafield.freezed.dart
@@ -25,7 +25,8 @@ mixin _$Metafield {
   String get key => throw _privateConstructorUsedError;
   String get value => throw _privateConstructorUsedError;
   String get type => throw _privateConstructorUsedError;
-  String get description => throw _privateConstructorUsedError;
+  String? get description => throw _privateConstructorUsedError;
+  Map<String, dynamic>? get reference => throw _privateConstructorUsedError;
 
   /// Serializes this Metafield to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -48,7 +49,8 @@ abstract class $MetafieldCopyWith<$Res> {
       String key,
       String value,
       String type,
-      String description});
+      String? description,
+      Map<String, dynamic>? reference});
 }
 
 /// @nodoc
@@ -71,7 +73,8 @@ class _$MetafieldCopyWithImpl<$Res, $Val extends Metafield>
     Object? key = null,
     Object? value = null,
     Object? type = null,
-    Object? description = null,
+    Object? description = freezed,
+    Object? reference = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -94,10 +97,14 @@ class _$MetafieldCopyWithImpl<$Res, $Val extends Metafield>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as String,
-      description: null == description
+      description: freezed == description
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
+      reference: freezed == reference
+          ? _value.reference
+          : reference // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
     ) as $Val);
   }
 }
@@ -116,7 +123,8 @@ abstract class _$$MetafieldImplCopyWith<$Res>
       String key,
       String value,
       String type,
-      String description});
+      String? description,
+      Map<String, dynamic>? reference});
 }
 
 /// @nodoc
@@ -137,7 +145,8 @@ class __$$MetafieldImplCopyWithImpl<$Res>
     Object? key = null,
     Object? value = null,
     Object? type = null,
-    Object? description = null,
+    Object? description = freezed,
+    Object? reference = freezed,
   }) {
     return _then(_$MetafieldImpl(
       id: null == id
@@ -160,10 +169,14 @@ class __$$MetafieldImplCopyWithImpl<$Res>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as String,
-      description: null == description
+      description: freezed == description
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
+      reference: freezed == reference
+          ? _value._reference
+          : reference // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
     ));
   }
 }
@@ -177,8 +190,10 @@ class _$MetafieldImpl extends _Metafield {
       required this.key,
       required this.value,
       required this.type,
-      this.description = ''})
-      : super._();
+      this.description,
+      final Map<String, dynamic>? reference})
+      : _reference = reference,
+        super._();
 
   factory _$MetafieldImpl.fromJson(Map<String, dynamic> json) =>
       _$$MetafieldImplFromJson(json);
@@ -194,12 +209,20 @@ class _$MetafieldImpl extends _Metafield {
   @override
   final String type;
   @override
-  @JsonKey()
-  final String description;
+  final String? description;
+  final Map<String, dynamic>? _reference;
+  @override
+  Map<String, dynamic>? get reference {
+    final value = _reference;
+    if (value == null) return null;
+    if (_reference is EqualUnmodifiableMapView) return _reference;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
 
   @override
   String toString() {
-    return 'Metafield(id: $id, namespace: $namespace, key: $key, value: $value, type: $type, description: $description)';
+    return 'Metafield(id: $id, namespace: $namespace, key: $key, value: $value, type: $type, description: $description, reference: $reference)';
   }
 
   @override
@@ -214,13 +237,15 @@ class _$MetafieldImpl extends _Metafield {
             (identical(other.value, value) || other.value == value) &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.description, description) ||
-                other.description == description));
+                other.description == description) &&
+            const DeepCollectionEquality()
+                .equals(other._reference, _reference));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, id, namespace, key, value, type, description);
+  int get hashCode => Object.hash(runtimeType, id, namespace, key, value, type,
+      description, const DeepCollectionEquality().hash(_reference));
 
   /// Create a copy of Metafield
   /// with the given fields replaced by the non-null parameter values.
@@ -245,7 +270,8 @@ abstract class _Metafield extends Metafield {
       required final String key,
       required final String value,
       required final String type,
-      final String description}) = _$MetafieldImpl;
+      final String? description,
+      final Map<String, dynamic>? reference}) = _$MetafieldImpl;
   _Metafield._() : super._();
 
   factory _Metafield.fromJson(Map<String, dynamic> json) =
@@ -262,7 +288,9 @@ abstract class _Metafield extends Metafield {
   @override
   String get type;
   @override
-  String get description;
+  String? get description;
+  @override
+  Map<String, dynamic>? get reference;
 
   /// Create a copy of Metafield
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/models/src/product/metafield/metafield.g.dart
+++ b/lib/models/src/product/metafield/metafield.g.dart
@@ -13,7 +13,8 @@ _$MetafieldImpl _$$MetafieldImplFromJson(Map<String, dynamic> json) =>
       key: json['key'] as String,
       value: json['value'] as String,
       type: json['type'] as String,
-      description: json['description'] as String? ?? '',
+      description: json['description'] as String?,
+      reference: json['reference'] as Map<String, dynamic>?,
     );
 
 Map<String, dynamic> _$$MetafieldImplToJson(_$MetafieldImpl instance) =>
@@ -24,4 +25,5 @@ Map<String, dynamic> _$$MetafieldImplToJson(_$MetafieldImpl instance) =>
       'value': instance.value,
       'type': instance.type,
       'description': instance.description,
+      'reference': instance.reference,
     };

--- a/lib/models/src/product/metafield_identifier/metafield_identifier.dart
+++ b/lib/models/src/product/metafield_identifier/metafield_identifier.dart
@@ -18,6 +18,5 @@ class MetafieldIdentifier with _$MetafieldIdentifier {
   }) = _MetafieldIdentifier;
 
   /// Metafield identifier from json
-  factory MetafieldIdentifier.fromJson(Map<String, dynamic> json) =>
-      _$MetafieldIdentifierFromJson(json);
+  factory MetafieldIdentifier.fromJson(Map<String, dynamic> json) => _$MetafieldIdentifierFromJson(json);
 }

--- a/lib/models/src/product/price_v_2/price_v_2.dart
+++ b/lib/models/src/product/price_v_2/price_v_2.dart
@@ -24,8 +24,7 @@ class PriceV2 with _$PriceV2 {
   }) = _PriceV2;
 
   /// The PriceV2 from json
-  factory PriceV2.fromJson(Map<String, dynamic> json) =>
-      _$PriceV2FromJson(json);
+  factory PriceV2.fromJson(Map<String, dynamic> json) => _$PriceV2FromJson(json);
 
   /// The formatted price
   String get formattedPrice => JsonHelper.chooseRightOrderOnCurrencySymbol(
@@ -35,8 +34,7 @@ class PriceV2 with _$PriceV2 {
       );
 
   /// The formatted price with locale
-  String formattedPriceWithLocale(String? locale) =>
-      JsonHelper.chooseRightOrderOnCurrencySymbol(
+  String formattedPriceWithLocale(String? locale) => JsonHelper.chooseRightOrderOnCurrencySymbol(
         amount,
         currencyCode,
         priceFormat: priceFormat,

--- a/lib/models/src/product/product.dart
+++ b/lib/models/src/product/product.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 
+import 'package:shopify_flutter/models/src/product/metafield/metafield.dart';
 import 'package:shopify_flutter/models/src/product/option/option.dart';
 import 'package:shopify_flutter/models/src/product/price_v_2/price_v_2.dart';
 import 'package:shopify_flutter/models/src/product/product_media/product_media.dart';
@@ -35,7 +36,7 @@ class Product with _$Product {
     required List<Option> options,
     required String vendor,
     required List<ProductMedia> media,
-    // required List<Metafield> metafields,
+    required List<Metafield> metafields,
     List<AssociatedCollections>? collectionList,
     String? cursor,
     String? onlineStoreUrl,
@@ -48,34 +49,29 @@ class Product with _$Product {
   ///
   /// This is the price of the product variant with the title 'Default Title'
   /// It is useful to show the price of the product in the product list
-  double get price =>
-      productVariants.isEmpty ? 0 : productVariants.first.price.amount;
+  double get price => productVariants.isEmpty ? 0 : productVariants.first.price.amount;
 
   /// return the first product variant price formatted or empty string if the list is empty
   ///
   /// This is the price of the product variant with the title 'Default Title'
   /// It is useful to show the price of the product in the product list
-  String get formattedPrice =>
-      productVariants.isEmpty ? '' : productVariants.first.price.formattedPrice;
+  String get formattedPrice => productVariants.isEmpty ? '' : productVariants.first.price.formattedPrice;
 
   /// return the first product variant price formatted with locale or empty string if the list is empty
   ///
   /// This is the price of the product variant with the title 'Default Title'
   /// It is useful to show the price of the product in the product list
-  String formattedPriceWithLocale(String? locale) => productVariants.isEmpty
-      ? ''
-      : productVariants.first.price.formattedPriceWithLocale(locale);
+  String formattedPriceWithLocale(String? locale) =>
+      productVariants.isEmpty ? '' : productVariants.first.price.formattedPriceWithLocale(locale);
 
   /// return the first product variant compareAtPrice amount or '' if the list is empty
   ///
   /// It is useful to show the compareAtPrice of the product in the product list
-  String compareAtPriceFormattedWithLocale(String? locale) =>
-      productVariants.isEmpty
+  String compareAtPriceFormattedWithLocale(String? locale) => productVariants.isEmpty
+      ? ''
+      : (productVariants.first.compareAtPrice == null
           ? ''
-          : (productVariants.first.compareAtPrice == null
-              ? ''
-              : productVariants.first.compareAtPrice!
-                  .formattedPriceWithLocale(locale));
+          : productVariants.first.compareAtPrice!.formattedPriceWithLocale(locale));
 
   /// return bool if compareAtPrice is greater than price
   bool get hasComparablePrice => compareAtPrice > price;
@@ -85,18 +81,14 @@ class Product with _$Product {
   /// It is useful to show the compareAtPrice of the product in the product list
   double get compareAtPrice => productVariants.isEmpty
       ? 0
-      : (productVariants.first.compareAtPrice == null
-          ? 0
-          : productVariants.first.compareAtPrice!.amount);
+      : (productVariants.first.compareAtPrice == null ? 0 : productVariants.first.compareAtPrice!.amount);
 
   /// return the first product variant compareAtPrice formatted or empty string if the list is empty
   ///
   /// It is useful to show the compareAtPrice of the product in the product list
   String get compareAtPriceFormatted => productVariants.isEmpty
       ? ''
-      : (productVariants.first.compareAtPrice == null
-          ? ''
-          : productVariants.first.compareAtPrice!.formattedPrice);
+      : (productVariants.first.compareAtPrice == null ? '' : productVariants.first.compareAtPrice!.formattedPrice);
 
   /// returns first image src or a placeholder image
   ///
@@ -108,19 +100,16 @@ class Product with _$Product {
   /// returns cuurency code of the first product variant or empty string if the list is empty
   ///
   /// It is useful to show the currency code of the product in the product list
-  String get currencyCode =>
-      productVariants.isEmpty ? '' : productVariants.first.price.currencyCode;
+  String get currencyCode => productVariants.isEmpty ? '' : productVariants.first.price.currencyCode;
 
   /// Checks if the product is available for sale by checking its variants availability and quantity
   bool get isAvailableForSale {
-    final temp =
-        productVariants.where((e) => e.title == 'Default Title').toList();
+    final temp = productVariants.where((e) => e.title == 'Default Title').toList();
     if (temp.isNotEmpty) {
       return temp.first.availableForSale && temp.first.quantityAvailable > 0;
     } else {
       bool isAvailable = false;
-      final variants =
-          productVariants.where((e) => e.title != 'Default Title').toList();
+      final variants = productVariants.where((e) => e.title != 'Default Title').toList();
       for (int i = 0; i < variants.length; i++) {
         if (variants[i].availableForSale && variants[i].quantityAvailable > 0) {
           isAvailable = true;
@@ -152,7 +141,7 @@ class Product with _$Product {
         options: _getOptionList(json),
         vendor: json['node']?['vendor'],
         media: _getMediaList(json),
-        // metafields: _getMetafieldList(json),
+        metafields: _getMetafieldList(json),
       );
 
   // factory Product.fromJson(Map<String, dynamic> json) =>
@@ -183,7 +172,7 @@ class Product with _$Product {
       options: _getOptionList(json),
       vendor: json['vendor'],
       media: _getMediaList(json),
-      // metafields: _getMetafieldList(json),
+      metafields: _getMetafieldList(json),
     );
   }
 
@@ -199,33 +188,24 @@ class Product with _$Product {
         if (variants == null) return [];
         if (variants is Map) {
           if (variants['edges'] == null) return [];
-          return ((variants['edges'] ?? []) as List)
-              .map((v) => ProductVariant.fromGraphJson(v ?? const {}))
-              .toList();
+          return ((variants['edges'] ?? []) as List).map((v) => ProductVariant.fromGraphJson(v ?? const {})).toList();
         } else {
           return ((variants ?? []) as List).map((v) {
-            Map<String, dynamic> jsonVariant =
-                v is ProductVariant ? v.toJson() : v;
-            jsonVariant['price'] = jsonVariant['price'] is PriceV2
-                ? jsonVariant['price'].toJson()
-                : jsonVariant['price'];
-            jsonVariant['unitPrice'] = jsonVariant['unitPrice'] is PriceV2
-                ? jsonVariant['unitPrice'].toJson()
-                : jsonVariant['unitPrice'];
-            jsonVariant['compareAtPrice'] =
-                jsonVariant['compareAtPrice'] is PriceV2
-                    ? jsonVariant['compareAtPrice'].toJson()
-                    : jsonVariant['compareAtPrice'];
-            jsonVariant['image'] = jsonVariant['image'] is ShopifyImage
-                ? jsonVariant['image'].toJson()
-                : jsonVariant['image'];
-            jsonVariant['unitPriceMeasurement'] =
-                jsonVariant['unitPriceMeasurement'] is UnitPriceMeasurement
-                    ? jsonVariant['unitPriceMeasurement'].toJson()
-                    : jsonVariant['unitPriceMeasurement'];
-            jsonVariant['selectedOptions'] = jsonVariant['selectedOptions']
-                ?.map((e) => e is SelectedOption ? e.toJson() : e)
-                ?.toList();
+            Map<String, dynamic> jsonVariant = v is ProductVariant ? v.toJson() : v;
+            jsonVariant['price'] =
+                jsonVariant['price'] is PriceV2 ? jsonVariant['price'].toJson() : jsonVariant['price'];
+            jsonVariant['unitPrice'] =
+                jsonVariant['unitPrice'] is PriceV2 ? jsonVariant['unitPrice'].toJson() : jsonVariant['unitPrice'];
+            jsonVariant['compareAtPrice'] = jsonVariant['compareAtPrice'] is PriceV2
+                ? jsonVariant['compareAtPrice'].toJson()
+                : jsonVariant['compareAtPrice'];
+            jsonVariant['image'] =
+                jsonVariant['image'] is ShopifyImage ? jsonVariant['image'].toJson() : jsonVariant['image'];
+            jsonVariant['unitPriceMeasurement'] = jsonVariant['unitPriceMeasurement'] is UnitPriceMeasurement
+                ? jsonVariant['unitPriceMeasurement'].toJson()
+                : jsonVariant['unitPriceMeasurement'];
+            jsonVariant['selectedOptions'] =
+                jsonVariant['selectedOptions']?.map((e) => e is SelectedOption ? e.toJson() : e)?.toList();
             return ProductVariant.fromJson(jsonVariant);
           }).toList();
         }
@@ -241,9 +221,7 @@ class Product with _$Product {
     try {
       if (json.containsKey('node')) {
         if (json['node']?['options'] == null) return [];
-        return ((json['node']?['options'] ?? []) as List)
-            .map((v) => Option.fromJson(v ?? const {}))
-            .toList();
+        return ((json['node']?['options'] ?? []) as List).map((v) => Option.fromJson(v ?? const {})).toList();
       } else {
         if (json['options'] == null) return [];
         return ((json['options'] ?? []) as List).map((v) {
@@ -270,8 +248,7 @@ class Product with _$Product {
     return tags;
   }
 
-  static List<AssociatedCollections> _getCollectionList(
-      Map<String, dynamic> json) {
+  static List<AssociatedCollections> _getCollectionList(Map<String, dynamic> json) {
     try {
       if (json.containsKey('node')) {
         if (json['node']?['collections'] == null) return [];
@@ -285,8 +262,7 @@ class Product with _$Product {
           if (list['edges'] == null) return [];
           return ((list['edges'] ?? []) as List).map((v) {
             final jsonCollection = v is AssociatedCollections ? v.toJson() : v;
-            return AssociatedCollections.fromGraphJson(
-                jsonCollection ?? const {});
+            return AssociatedCollections.fromGraphJson(jsonCollection ?? const {});
           }).toList();
         } else {
           return ((list ?? []) as List).map((v) {
@@ -355,23 +331,30 @@ class Product with _$Product {
     }
   }
 
-  // static List<Metafield> _getMetafieldList(Map<String, dynamic> json) {
-  //   try {
-  //     if (json.containsKey('node')) {
-  //       if (json['node']?['metafields'] == null) return [];
-  //       return ((json['node']?['metafields']?['edges'] ?? []) as List)
-  //           .map((v) => Metafield.fromGraphJson(v ?? const {}))
-  //           .toList();
-  //     } else {
-  //       if (json['metafields'] == null) return [];
-  //       return ((json['metafields'] ?? []) as List).map((v) {
-  //         final jsonMetafield = v is Metafield ? v.toJson() : v;
-  //         return Metafield.fromJson(jsonMetafield ?? const {});
-  //       }).toList();
-  //     }
-  //   } catch (e) {
-  //     log("_getMetafieldList error: $e");
-  //     return [];
-  //   }
-  // }
+  static List<Metafield> _getMetafieldList(Map<String, dynamic> json) {
+    try {
+      if (json.containsKey('node')) {
+        if (json['node']?['metafields'] == null) return [];
+        final metafields =
+            ((json['node']?['metafields'] ?? []) as List).map((v) => Metafield.fromGraphJson(v ?? const {})).toList();
+        // remove null entries from the list
+        return metafields;
+      } else if (json['metafields'] != null) {
+        final metafields =
+            ((json['node']?['metafields'] ?? []) as List).map((v) => Metafield.fromGraphJson(v ?? const {})).toList();
+        // remove null entries from the list
+        return metafields;
+      } else if (json['nodes'] != null && json['nodes'].isNotEmpty) {
+        final metafields = ((json['nodes'][0]?['metafields'] ?? []) as List)
+            .map((v) => Metafield.fromGraphJson(v ?? const {}))
+            .toList();
+        // remove null entries from the list
+        return metafields;
+      }
+      return [];
+    } catch (e) {
+      log("_getMetafieldList error: $e");
+      return [];
+    }
+  }
 }

--- a/lib/models/src/product/product.freezed.dart
+++ b/lib/models/src/product/product.freezed.dart
@@ -29,8 +29,8 @@ mixin _$Product {
   List<ShopifyImage> get images => throw _privateConstructorUsedError;
   List<Option> get options => throw _privateConstructorUsedError;
   String get vendor => throw _privateConstructorUsedError;
-  List<ProductMedia> get media =>
-      throw _privateConstructorUsedError; // required List<Metafield> metafields,
+  List<ProductMedia> get media => throw _privateConstructorUsedError;
+  List<Metafield> get metafields => throw _privateConstructorUsedError;
   List<AssociatedCollections>? get collectionList =>
       throw _privateConstructorUsedError;
   String? get cursor => throw _privateConstructorUsedError;
@@ -64,6 +64,7 @@ abstract class $ProductCopyWith<$Res> {
       List<Option> options,
       String vendor,
       List<ProductMedia> media,
+      List<Metafield> metafields,
       List<AssociatedCollections>? collectionList,
       String? cursor,
       String? onlineStoreUrl,
@@ -100,6 +101,7 @@ class _$ProductCopyWithImpl<$Res, $Val extends Product>
     Object? options = null,
     Object? vendor = null,
     Object? media = null,
+    Object? metafields = null,
     Object? collectionList = freezed,
     Object? cursor = freezed,
     Object? onlineStoreUrl = freezed,
@@ -160,6 +162,10 @@ class _$ProductCopyWithImpl<$Res, $Val extends Product>
           ? _value.media
           : media // ignore: cast_nullable_to_non_nullable
               as List<ProductMedia>,
+      metafields: null == metafields
+          ? _value.metafields
+          : metafields // ignore: cast_nullable_to_non_nullable
+              as List<Metafield>,
       collectionList: freezed == collectionList
           ? _value.collectionList
           : collectionList // ignore: cast_nullable_to_non_nullable
@@ -209,6 +215,7 @@ abstract class _$$ProductImplCopyWith<$Res> implements $ProductCopyWith<$Res> {
       List<Option> options,
       String vendor,
       List<ProductMedia> media,
+      List<Metafield> metafields,
       List<AssociatedCollections>? collectionList,
       String? cursor,
       String? onlineStoreUrl,
@@ -243,6 +250,7 @@ class __$$ProductImplCopyWithImpl<$Res>
     Object? options = null,
     Object? vendor = null,
     Object? media = null,
+    Object? metafields = null,
     Object? collectionList = freezed,
     Object? cursor = freezed,
     Object? onlineStoreUrl = freezed,
@@ -303,6 +311,10 @@ class __$$ProductImplCopyWithImpl<$Res>
           ? _value._media
           : media // ignore: cast_nullable_to_non_nullable
               as List<ProductMedia>,
+      metafields: null == metafields
+          ? _value._metafields
+          : metafields // ignore: cast_nullable_to_non_nullable
+              as List<Metafield>,
       collectionList: freezed == collectionList
           ? _value._collectionList
           : collectionList // ignore: cast_nullable_to_non_nullable
@@ -348,6 +360,7 @@ class _$ProductImpl extends _Product {
       required final List<Option> options,
       required this.vendor,
       required final List<ProductMedia> media,
+      required final List<Metafield> metafields,
       final List<AssociatedCollections>? collectionList,
       this.cursor,
       this.onlineStoreUrl,
@@ -359,6 +372,7 @@ class _$ProductImpl extends _Product {
         _images = images,
         _options = options,
         _media = media,
+        _metafields = metafields,
         _collectionList = collectionList,
         super._();
 
@@ -418,9 +432,15 @@ class _$ProductImpl extends _Product {
     return EqualUnmodifiableListView(_media);
   }
 
-// required List<Metafield> metafields,
+  final List<Metafield> _metafields;
+  @override
+  List<Metafield> get metafields {
+    if (_metafields is EqualUnmodifiableListView) return _metafields;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_metafields);
+  }
+
   final List<AssociatedCollections>? _collectionList;
-// required List<Metafield> metafields,
   @override
   List<AssociatedCollections>? get collectionList {
     final value = _collectionList;
@@ -443,7 +463,7 @@ class _$ProductImpl extends _Product {
 
   @override
   String toString() {
-    return 'Product(title: $title, id: $id, availableForSale: $availableForSale, createdAt: $createdAt, productVariants: $productVariants, productType: $productType, publishedAt: $publishedAt, tags: $tags, updatedAt: $updatedAt, images: $images, options: $options, vendor: $vendor, media: $media, collectionList: $collectionList, cursor: $cursor, onlineStoreUrl: $onlineStoreUrl, description: $description, descriptionHtml: $descriptionHtml, handle: $handle)';
+    return 'Product(title: $title, id: $id, availableForSale: $availableForSale, createdAt: $createdAt, productVariants: $productVariants, productType: $productType, publishedAt: $publishedAt, tags: $tags, updatedAt: $updatedAt, images: $images, options: $options, vendor: $vendor, media: $media, metafields: $metafields, collectionList: $collectionList, cursor: $cursor, onlineStoreUrl: $onlineStoreUrl, description: $description, descriptionHtml: $descriptionHtml, handle: $handle)';
   }
 
   @override
@@ -470,6 +490,8 @@ class _$ProductImpl extends _Product {
             const DeepCollectionEquality().equals(other._options, _options) &&
             (identical(other.vendor, vendor) || other.vendor == vendor) &&
             const DeepCollectionEquality().equals(other._media, _media) &&
+            const DeepCollectionEquality()
+                .equals(other._metafields, _metafields) &&
             const DeepCollectionEquality()
                 .equals(other._collectionList, _collectionList) &&
             (identical(other.cursor, cursor) || other.cursor == cursor) &&
@@ -498,6 +520,7 @@ class _$ProductImpl extends _Product {
         const DeepCollectionEquality().hash(_options),
         vendor,
         const DeepCollectionEquality().hash(_media),
+        const DeepCollectionEquality().hash(_metafields),
         const DeepCollectionEquality().hash(_collectionList),
         cursor,
         onlineStoreUrl,
@@ -530,6 +553,7 @@ abstract class _Product extends Product {
       required final List<Option> options,
       required final String vendor,
       required final List<ProductMedia> media,
+      required final List<Metafield> metafields,
       final List<AssociatedCollections>? collectionList,
       final String? cursor,
       final String? onlineStoreUrl,
@@ -563,7 +587,9 @@ abstract class _Product extends Product {
   @override
   String get vendor;
   @override
-  List<ProductMedia> get media; // required List<Metafield> metafields,
+  List<ProductMedia> get media;
+  @override
+  List<Metafield> get metafields;
   @override
   List<AssociatedCollections>? get collectionList;
   @override

--- a/lib/models/src/product/product.g.dart
+++ b/lib/models/src/product/product.g.dart
@@ -20,6 +20,7 @@ Map<String, dynamic> _$ProductToJson(Product instance) => <String, dynamic>{
       'options': instance.options,
       'vendor': instance.vendor,
       'media': instance.media,
+      'metafields': instance.metafields,
       'collectionList': instance.collectionList,
       'cursor': instance.cursor,
       'onlineStoreUrl': instance.onlineStoreUrl,

--- a/lib/models/src/product/product_media/product_media.dart
+++ b/lib/models/src/product/product_media/product_media.dart
@@ -25,13 +25,10 @@ class ProductMedia with _$ProductMedia {
       id: nodeJson['id'],
       mediaContentType: nodeJson['mediaContentType'],
       alt: nodeJson['alt'],
-      image: nodeJson['previewImage'] != null
-          ? ShopifyImage.fromJson(nodeJson['previewImage'])
-          : null,
+      image: nodeJson['previewImage'] != null ? ShopifyImage.fromJson(nodeJson['previewImage']) : null,
     );
   }
 
   /// The product media from json
-  factory ProductMedia.fromJson(Map<String, dynamic> json) =>
-      _$ProductMediaFromJson(json);
+  factory ProductMedia.fromJson(Map<String, dynamic> json) => _$ProductMediaFromJson(json);
 }

--- a/lib/models/src/product/product_variant/product_variant.dart
+++ b/lib/models/src/product/product_variant/product_variant.dart
@@ -41,19 +41,14 @@ class ProductVariant with _$ProductVariant {
     Map<String, dynamic> json, {
     bool forceParse = false,
   }) {
-    Map<String, dynamic> nodeJson =
-        json['node'] ?? (forceParse ? json : const {});
+    Map<String, dynamic> nodeJson = json['node'] ?? (forceParse ? json : const {});
 
     return ProductVariant(
-      price: nodeJson.containsKey('priceV2')
-          ? PriceV2.fromJson(nodeJson['priceV2'])
-          : PriceV2.fromJson(nodeJson['price']),
+      price:
+          nodeJson.containsKey('priceV2') ? PriceV2.fromJson(nodeJson['priceV2']) : PriceV2.fromJson(nodeJson['price']),
       title: nodeJson['title'],
-      image: nodeJson['image'] != null
-          ? ShopifyImage.fromJson(nodeJson['image'])
-          : null,
-      compareAtPrice: nodeJson['compareAtPrice'] != null ||
-              nodeJson['compareAtPriceV2'] != null
+      image: nodeJson['image'] != null ? ShopifyImage.fromJson(nodeJson['image']) : null,
+      compareAtPrice: nodeJson['compareAtPrice'] != null || nodeJson['compareAtPriceV2'] != null
           ? nodeJson.containsKey('compareAtPrice')
               ? PriceV2.fromJson(nodeJson['compareAtPrice'])
               : PriceV2.fromJson(nodeJson['compareAtPriceV2'])
@@ -65,23 +60,18 @@ class ProductVariant with _$ProductVariant {
       id: nodeJson['id'],
       quantityAvailable: nodeJson['quantityAvailable'],
       sku: nodeJson['sku'],
-      unitPrice: nodeJson['unitPrice'] != null
-          ? PriceV2.fromJson(nodeJson['unitPrice'])
-          : null,
+      unitPrice: nodeJson['unitPrice'] != null ? PriceV2.fromJson(nodeJson['unitPrice']) : null,
       unitPriceMeasurement: nodeJson['unitPriceMeasurement'] != null
           ? UnitPriceMeasurement.fromJson(nodeJson['unitPriceMeasurement'])
           : null,
       selectedOptions: _getOptionList((nodeJson)),
-      product: nodeJson['product'] != null
-          ? Product.fromJson(nodeJson['product'])
-          : null,
+      product: nodeJson['product'] != null ? Product.fromJson(nodeJson['product']) : null,
       sellingPlanAllocations: _getSellingPlanAllocationsList(nodeJson),
     );
   }
 
   /// the product variant from json
-  factory ProductVariant.fromJson(Map<String, dynamic> json) =>
-      _$ProductVariantFromJson(json);
+  factory ProductVariant.fromJson(Map<String, dynamic> json) => _$ProductVariantFromJson(json);
 
   static List<SelectedOption> _getOptionList(Map<String, dynamic> json) {
     List<SelectedOption> optionList = [];
@@ -91,8 +81,7 @@ class ProductVariant with _$ProductVariant {
     return optionList;
   }
 
-  static List<SellingPlanAllocation> _getSellingPlanAllocationsList(
-      Map<String, dynamic> json) {
+  static List<SellingPlanAllocation> _getSellingPlanAllocationsList(Map<String, dynamic> json) {
     List<SellingPlanAllocation> sellingPlanAllocationsList = [];
     (json['sellingPlanAllocations']?['nodes'] ?? []).forEach((v) {
       if (v != null) {

--- a/lib/models/src/product/products/products.dart
+++ b/lib/models/src/product/products/products.dart
@@ -23,13 +23,9 @@ class Products with _$Products {
       );
 
   static List<Product> _getProductList(Map<String, dynamic> json) {
-    return (json['edges'] as List?)
-            ?.map((e) => Product.fromGraphJson(e ?? const {}))
-            .toList() ??
-        const <Product>[];
+    return (json['edges'] as List?)?.map((e) => Product.fromGraphJson(e ?? const {})).toList() ?? const <Product>[];
   }
 
   /// The products from json factory
-  factory Products.fromJson(Map<String, dynamic> json) =>
-      _$ProductsFromJson(json);
+  factory Products.fromJson(Map<String, dynamic> json) => _$ProductsFromJson(json);
 }

--- a/lib/models/src/product/selected_option/selected_option.dart
+++ b/lib/models/src/product/selected_option/selected_option.dart
@@ -16,6 +16,5 @@ class SelectedOption with _$SelectedOption {
   }) = _SelectedOption;
 
   /// The SelectedOption from json
-  factory SelectedOption.fromJson(Map<String, dynamic> json) =>
-      _$SelectedOptionFromJson(json);
+  factory SelectedOption.fromJson(Map<String, dynamic> json) => _$SelectedOptionFromJson(json);
 }

--- a/lib/models/src/product/selling_plan_allocation/selling_plan/selling_plan.dart
+++ b/lib/models/src/product/selling_plan_allocation/selling_plan/selling_plan.dart
@@ -24,6 +24,5 @@ class SellingPlan with _$SellingPlan {
   }) = _SellingPlan;
 
   /// The SellingPlan from json
-  factory SellingPlan.fromJson(Map<String, dynamic> json) =>
-      _$SellingPlanFromJson(json);
+  factory SellingPlan.fromJson(Map<String, dynamic> json) => _$SellingPlanFromJson(json);
 }

--- a/lib/models/src/product/selling_plan_allocation/selling_plan/selling_plan_option/selling_plan_option.dart
+++ b/lib/models/src/product/selling_plan_allocation/selling_plan/selling_plan_option/selling_plan_option.dart
@@ -16,6 +16,5 @@ class SellingPlanOption with _$SellingPlanOption {
   }) = _SellingPlanOption;
 
   /// The SellingPlanOption from json
-  factory SellingPlanOption.fromJson(Map<String, dynamic> json) =>
-      _$SellingPlanOptionFromJson(json);
+  factory SellingPlanOption.fromJson(Map<String, dynamic> json) => _$SellingPlanOptionFromJson(json);
 }

--- a/lib/models/src/product/selling_plan_allocation/selling_plan_allocation.dart
+++ b/lib/models/src/product/selling_plan_allocation/selling_plan_allocation.dart
@@ -19,6 +19,5 @@ class SellingPlanAllocation with _$SellingPlanAllocation {
   }) = _SellingPlanAllocation;
 
   /// The SellingPlanAllocation from json
-  factory SellingPlanAllocation.fromJson(Map<String, dynamic> json) =>
-      _$SellingPlanAllocationFromJson(json);
+  factory SellingPlanAllocation.fromJson(Map<String, dynamic> json) => _$SellingPlanAllocationFromJson(json);
 }

--- a/lib/models/src/product/shopify_image/shopify_image.dart
+++ b/lib/models/src/product/shopify_image/shopify_image.dart
@@ -17,6 +17,5 @@ class ShopifyImage with _$ShopifyImage {
   }) = _ShopifyImage;
 
   /// The ShopifyImage from json
-  factory ShopifyImage.fromJson(Map<String, dynamic> json) =>
-      _$ShopifyImageFromJson(json);
+  factory ShopifyImage.fromJson(Map<String, dynamic> json) => _$ShopifyImageFromJson(json);
 }

--- a/lib/models/src/product/unit_price_measurement/unit_price_measurement.dart
+++ b/lib/models/src/product/unit_price_measurement/unit_price_measurement.dart
@@ -19,6 +19,5 @@ class UnitPriceMeasurement with _$UnitPriceMeasurement {
   }) = _UnitPriceMeasurement;
 
   /// The unit price measurement from json
-  factory UnitPriceMeasurement.fromJson(Map<String, dynamic> json) =>
-      _$UnitPriceMeasurementFromJson(json);
+  factory UnitPriceMeasurement.fromJson(Map<String, dynamic> json) => _$UnitPriceMeasurementFromJson(json);
 }

--- a/lib/models/src/shop/payment_settings/payment_settings.dart
+++ b/lib/models/src/shop/payment_settings/payment_settings.dart
@@ -19,6 +19,5 @@ class PaymentSettings with _$PaymentSettings {
   }) = _PaymentSettings;
 
   /// The PaymentSettings from json
-  factory PaymentSettings.fromJson(Map<String, dynamic> json) =>
-      _$PaymentSettingsFromJson(json);
+  factory PaymentSettings.fromJson(Map<String, dynamic> json) => _$PaymentSettingsFromJson(json);
 }

--- a/lib/models/src/shop/primary_domain/primary_domain.dart
+++ b/lib/models/src/shop/primary_domain/primary_domain.dart
@@ -8,10 +8,8 @@ part 'primary_domain.g.dart';
 /// The PrimaryDomain class
 class PrimaryDomain with _$PrimaryDomain {
   ///  The PrimaryDomain constructor
-  factory PrimaryDomain({String? host, bool? sslEnabled, String? url}) =
-      _PrimaryDomain;
+  factory PrimaryDomain({String? host, bool? sslEnabled, String? url}) = _PrimaryDomain;
 
   /// The PrimaryDomain from json
-  factory PrimaryDomain.fromJson(Map<String, dynamic> json) =>
-      _$PrimaryDomainFromJson(json);
+  factory PrimaryDomain.fromJson(Map<String, dynamic> json) => _$PrimaryDomainFromJson(json);
 }

--- a/lib/models/src/shop/privacy_policy/privacy_policy.dart
+++ b/lib/models/src/shop/privacy_policy/privacy_policy.dart
@@ -17,6 +17,5 @@ class PrivacyPolicy with _$PrivacyPolicy {
   }) = _PrivacyPolicy;
 
   /// The PrivacyPolicy from json
-  factory PrivacyPolicy.fromJson(Map<String, dynamic> json) =>
-      _$PrivacyPolicyFromJson(json);
+  factory PrivacyPolicy.fromJson(Map<String, dynamic> json) => _$PrivacyPolicyFromJson(json);
 }

--- a/lib/models/src/shop/refund_policy/refund_policy.dart
+++ b/lib/models/src/shop/refund_policy/refund_policy.dart
@@ -17,6 +17,5 @@ class RefundPolicy with _$RefundPolicy {
   }) = _RefundPolicy;
 
   /// The RefundPolicy from json
-  factory RefundPolicy.fromJson(Map<String, dynamic> json) =>
-      _$RefundPolicyFromJson(json);
+  factory RefundPolicy.fromJson(Map<String, dynamic> json) => _$RefundPolicyFromJson(json);
 }

--- a/lib/models/src/shop/shipping_policy/shipping_policy.dart
+++ b/lib/models/src/shop/shipping_policy/shipping_policy.dart
@@ -17,6 +17,5 @@ class ShippingPolicy with _$ShippingPolicy {
   }) = _ShippingPolicy;
 
   /// The ShippingPolicy from json
-  factory ShippingPolicy.fromJson(Map<String, dynamic> json) =>
-      _$ShippingPolicyFromJson(json);
+  factory ShippingPolicy.fromJson(Map<String, dynamic> json) => _$ShippingPolicyFromJson(json);
 }

--- a/lib/models/src/shop/subscription_policy/subscription_policy.dart
+++ b/lib/models/src/shop/subscription_policy/subscription_policy.dart
@@ -17,6 +17,5 @@ class SubscriptionPolicy with _$SubscriptionPolicy {
   }) = _SubscriptionPolicy;
 
   /// The SubscriptionPolicy from json
-  factory SubscriptionPolicy.fromJson(Map<String, dynamic> json) =>
-      _$SubscriptionPolicyFromJson(json);
+  factory SubscriptionPolicy.fromJson(Map<String, dynamic> json) => _$SubscriptionPolicyFromJson(json);
 }

--- a/lib/models/src/shop/terms_of_service/terms_of_service.dart
+++ b/lib/models/src/shop/terms_of_service/terms_of_service.dart
@@ -17,6 +17,5 @@ class TermsOfService with _$TermsOfService {
   }) = _TermsOfService;
 
   /// The TermsOfService from json
-  factory TermsOfService.fromJson(Map<String, dynamic> json) =>
-      _$TermsOfServiceFromJson(json);
+  factory TermsOfService.fromJson(Map<String, dynamic> json) => _$TermsOfServiceFromJson(json);
 }

--- a/lib/models/src/shopify_user/access_token_with_exp_date.dart
+++ b/lib/models/src/shopify_user/access_token_with_exp_date.dart
@@ -22,8 +22,7 @@ class AccessTokenWithExpDate {
 
   factory AccessTokenWithExpDate.fromMap(Map<String, dynamic> map) {
     return AccessTokenWithExpDate(
-      accessToken:
-          map['accessToken'] != null ? map['accessToken'] as String : null,
+      accessToken: map['accessToken'] != null ? map['accessToken'] as String : null,
       expiresAt: map['expiresAt'] != null
           ? map['expiresAt'] is String
               ? DateTime.parse(map['expiresAt'] as String)
@@ -35,10 +34,8 @@ class AccessTokenWithExpDate {
   String toJson() => json.encode(toMap());
 
   factory AccessTokenWithExpDate.fromJson(String source) =>
-      AccessTokenWithExpDate.fromMap(
-          json.decode(source) as Map<String, dynamic>);
+      AccessTokenWithExpDate.fromMap(json.decode(source) as Map<String, dynamic>);
 
   @override
-  String toString() =>
-      'AccessTokenWithExpDate(accessToken: $accessToken, expiresAt: $expiresAt)';
+  String toString() => 'AccessTokenWithExpDate(accessToken: $accessToken, expiresAt: $expiresAt)';
 }

--- a/lib/models/src/shopify_user/address/address.dart
+++ b/lib/models/src/shopify_user/address/address.dart
@@ -52,6 +52,5 @@ class Address with _$Address {
       );
 
   /// The address from json factory
-  factory Address.fromJson(Map<String, dynamic> json) =>
-      _$AddressFromJson(json);
+  factory Address.fromJson(Map<String, dynamic> json) => _$AddressFromJson(json);
 }

--- a/lib/models/src/shopify_user/addresses/addresses.dart
+++ b/lib/models/src/shopify_user/addresses/addresses.dart
@@ -14,17 +14,14 @@ class Addresses with _$Addresses {
   factory Addresses({required List<Address> addressList}) = _Addresses;
 
   /// The addresses from json factory
-  factory Addresses.fromJson(Map<String, dynamic> json) =>
-      _$AddressesFromJson(json);
+  factory Addresses.fromJson(Map<String, dynamic> json) => _$AddressesFromJson(json);
 
   /// The addresses from graph json factory
-  factory Addresses.fromGraphJson(Map<String, dynamic> json) =>
-      Addresses(addressList: _getAddressList(json));
+  factory Addresses.fromGraphJson(Map<String, dynamic> json) => Addresses(addressList: _getAddressList(json));
 
   static _getAddressList(Map<String, dynamic> json) {
     List<Address> addressList = [];
-    json['edges']?.forEach((address) =>
-        addressList.add(Address.fromGraphJson(address ?? const [])));
+    json['edges']?.forEach((address) => addressList.add(Address.fromGraphJson(address ?? const [])));
     return addressList;
   }
 }

--- a/lib/models/src/shopify_user/shopify_user.dart
+++ b/lib/models/src/shopify_user/shopify_user.dart
@@ -27,9 +27,7 @@ class ShopifyUser with _$ShopifyUser {
   /// The shopify user from json factory
   factory ShopifyUser.fromGraphJson(Map<String, dynamic> json) => ShopifyUser(
         address: Addresses.fromGraphJson(json['addresses'] ?? const {}),
-        defaultAddress: json['defaultAddress'] == null
-            ? null
-            : Address.fromJson(json['defaultAddress']),
+        defaultAddress: json['defaultAddress'] == null ? null : Address.fromJson(json['defaultAddress']),
         createdAt: json['createdAt'],
         displayName: json['displayName'],
         email: json['email'],
@@ -41,8 +39,7 @@ class ShopifyUser with _$ShopifyUser {
       );
 
   /// The shopify user from json factory
-  factory ShopifyUser.fromJson(Map<String, dynamic> json) =>
-      _$ShopifyUserFromJson(json);
+  factory ShopifyUser.fromJson(Map<String, dynamic> json) => _$ShopifyUserFromJson(json);
 
   static _getTagList(Map<String, dynamic> json) {
     List<String> tagsList = [];

--- a/lib/shopify/src/shopify_auth.dart
+++ b/lib/shopify/src/shopify_auth.dart
@@ -44,8 +44,7 @@ class ShopifyAuth with ShopifyError {
         accessTokenWithExpDate = AccessTokenWithExpDate.fromJson(
           _prefs.getString(ShopifyConfig.storeUrl!)!,
         );
-        _currentCustomerAccessToken[ShopifyConfig.storeUrl] =
-            accessTokenWithExpDate.toJson();
+        _currentCustomerAccessToken[ShopifyConfig.storeUrl] = accessTokenWithExpDate.toJson();
       }
     }
     return accessTokenWithExpDate;
@@ -134,10 +133,8 @@ class ShopifyAuth with ShopifyError {
       key: 'customerCreate',
       errorKey: 'customerUserErrors',
     );
-    final shopifyUser = ShopifyUser.fromGraphJson(
-        (result.data!['customerCreate'] ?? const {})['customer']);
-    final AccessTokenWithExpDate accessTokenWithExpDate =
-        await _createAccessToken(
+    final shopifyUser = ShopifyUser.fromGraphJson((result.data!['customerCreate'] ?? const {})['customer']);
+    final AccessTokenWithExpDate accessTokenWithExpDate = await _createAccessToken(
       email,
       password,
     );
@@ -154,8 +151,8 @@ class ShopifyAuth with ShopifyError {
   Future<void> sendPasswordResetEmail({
     required String email,
   }) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(customerRecoverMutation), variables: {'email': email});
+    final MutationOptions _options =
+        MutationOptions(document: gql(customerRecoverMutation), variables: {'email': email});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -169,8 +166,7 @@ class ShopifyAuth with ShopifyError {
     required String email,
     required String password,
   }) async {
-    final AccessTokenWithExpDate accessTokenWithExpDate =
-        await _createAccessToken(email, password);
+    final AccessTokenWithExpDate accessTokenWithExpDate = await _createAccessToken(email, password);
     if (accessTokenWithExpDate.accessToken == null) {
       throw Exception('Invalid credentials');
     }
@@ -189,16 +185,14 @@ class ShopifyAuth with ShopifyError {
   /// Renews the current access token.
   Future<void> renewCurrentAccessToken(String accessToken) async {
     final updatedAccessToken = await _renewAccessToken(accessToken);
-    await _setShopifyUser(
-        updatedAccessToken, _shopifyUser[ShopifyConfig.storeUrl]);
+    await _setShopifyUser(updatedAccessToken, _shopifyUser[ShopifyConfig.storeUrl]);
   }
 
   /// Tries to sign in a user with the given Multipass token.
   Future<ShopifyUser> signInWithMultipassToken(
     final String multipassToken,
   ) async {
-    final accessTokenWithExpDate =
-        await _createAccessTokenWithMultipass(multipassToken);
+    final accessTokenWithExpDate = await _createAccessTokenWithMultipass(multipassToken);
     final WatchQueryOptions _getCustomer = WatchQueryOptions(
       document: gql(getCustomerQuery),
       variables: {'customerAccessToken': accessTokenWithExpDate.accessToken},
@@ -217,12 +211,10 @@ class ShopifyAuth with ShopifyError {
     String email,
     String password,
   ) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(customerAccessTokenCreate),
-        variables: {'email': email, 'password': password});
+    final MutationOptions _options =
+        MutationOptions(document: gql(customerAccessTokenCreate), variables: {'email': email, 'password': password});
     final QueryResult result = await _graphQLClient!.mutate(_options);
-    return _extractAccessTokenWithExpDate(
-        result.data, "customerAccessTokenCreate");
+    return _extractAccessTokenWithExpDate(result.data, "customerAccessTokenCreate");
   }
 
   /// Helper method for creating the accessToken with Multipass.
@@ -230,8 +222,7 @@ class ShopifyAuth with ShopifyError {
     String multipassToken,
   ) async {
     final MutationOptions _options = MutationOptions(
-        document: gql(customerAccessTokenCreateWithMultipassMutation),
-        variables: {'multipassToken': multipassToken});
+        document: gql(customerAccessTokenCreateWithMultipassMutation), variables: {'multipassToken': multipassToken});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     return _extractAccessTokenWithExpDate(
       result.data,
@@ -257,8 +248,7 @@ class ShopifyAuth with ShopifyError {
       return;
     }
     final MutationOptions _options = MutationOptions(
-        document: gql(accessTokenDeleteMutation),
-        variables: {'customerAccessToken': await currentCustomerAccessToken});
+        document: gql(accessTokenDeleteMutation), variables: {'customerAccessToken': await currentCustomerAccessToken});
     await _setShopifyUser(null, null);
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
@@ -273,11 +263,9 @@ class ShopifyAuth with ShopifyError {
     String customerAccessToken,
   ) async {
     final MutationOptions _options = MutationOptions(
-        document: gql(customerAccessTokenRenewMutation),
-        variables: {'customerAccessToken': customerAccessToken});
+        document: gql(customerAccessTokenRenewMutation), variables: {'customerAccessToken': customerAccessToken});
     final QueryResult result = await _graphQLClient!.mutate(_options);
-    return _extractAccessTokenWithExpDate(
-        result.data, "customerAccessTokenRenew");
+    return _extractAccessTokenWithExpDate(result.data, "customerAccessTokenRenew");
   }
 
   /// Returns the currently signed-in [ShopifyUser] or [null] if there is none.
@@ -310,8 +298,7 @@ class ShopifyAuth with ShopifyError {
     );
     final QueryResult result = (await _graphQLClient!.query(_getCustomer));
     checkForError(result);
-    ShopifyUser user = ShopifyUser.fromGraphJson(
-        (result.data ?? const {})['customer'] ?? const {});
+    ShopifyUser user = ShopifyUser.fromGraphJson((result.data ?? const {})['customer'] ?? const {});
     final updatedAccessToken = await _renewAccessToken(accessToken);
     await _setShopifyUser(updatedAccessToken, user);
     return user;
@@ -331,10 +318,8 @@ class ShopifyAuth with ShopifyError {
       _prefs.remove(ShopifyConfig.storeUrl!);
     } else {
       _shopifyUser[ShopifyConfig.storeUrl] = shopifyUser;
-      _currentCustomerAccessToken[ShopifyConfig.storeUrl] =
-          accessTokenWithExpDate.toJson();
-      _prefs.setString(
-          ShopifyConfig.storeUrl!, accessTokenWithExpDate.toJson());
+      _currentCustomerAccessToken[ShopifyConfig.storeUrl] = accessTokenWithExpDate.toJson();
+      _prefs.setString(ShopifyConfig.storeUrl!, accessTokenWithExpDate.toJson());
     }
   }
 

--- a/lib/shopify/src/shopify_blog.dart
+++ b/lib/shopify/src/shopify_blog.dart
@@ -24,9 +24,7 @@ class ShopifyBlog with ShopifyError {
   ///
   /// Returns All [Blog] of the Shop.
   Future<List<Blog>?> getAllBlogs(
-      {SortKeyBlog sortKeyBlog = SortKeyBlog.HANDLE,
-      bool reverseBlogs = false,
-      bool reverseArticles = false}) async {
+      {SortKeyBlog sortKeyBlog = SortKeyBlog.HANDLE, bool reverseBlogs = false, bool reverseArticles = false}) async {
     final WatchQueryOptions _options = WatchQueryOptions(
       document: gql(getAllBlogsQuery),
       variables: {
@@ -38,8 +36,7 @@ class ShopifyBlog with ShopifyError {
     );
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
-    return (Blogs.fromGraphJson((result.data ?? const {})["blogs"] ?? const {}))
-        .blogList;
+    return (Blogs.fromGraphJson((result.data ?? const {})["blogs"] ?? const {})).blogList;
   }
 
   /// Returns a [Blog].
@@ -47,15 +44,10 @@ class ShopifyBlog with ShopifyError {
   /// Returns the [Blog] that is associated to the [handle].
   /// [sortKeyArticle] is meant for the List of [Article] in the [Blog].
   Future<Blog> getBlogByHandle(String handle,
-      {SortKeyArticle sortKeyArticle = SortKeyArticle.RELEVANCE,
-      bool reverse = false}) async {
+      {SortKeyArticle sortKeyArticle = SortKeyArticle.RELEVANCE, bool reverse = false}) async {
     final QueryOptions _options = WatchQueryOptions(
       document: gql(getBlogByHandleQuery),
-      variables: {
-        'handle': handle,
-        'sortKey': sortKeyArticle.parseToString(),
-        'reverseArticles': reverse
-      },
+      variables: {'handle': handle, 'sortKey': sortKeyArticle.parseToString(), 'reverseArticles': reverse},
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
     final QueryResult result = await _graphQLClient!.query(_options);
@@ -83,8 +75,6 @@ class ShopifyBlog with ShopifyError {
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
 
-    return (Articles.fromJson(
-            (result.data ?? const {})['articles'] ?? const {}))
-        .articleList;
+    return (Articles.fromJson((result.data ?? const {})['articles'] ?? const {})).articleList;
   }
 }

--- a/lib/shopify/src/shopify_cart.dart
+++ b/lib/shopify/src/shopify_cart.dart
@@ -60,8 +60,7 @@ class ShopifyCart with ShopifyError {
     QueryResult result = await _graphQLClient!.mutate(createCart);
     checkForError(result, key: 'cartCreate', errorKey: 'userErrors');
 
-    return Cart.fromJson(
-        ((result.data!['cartCreate'] ?? const {})['cart'] ?? const {}));
+    return Cart.fromJson(((result.data!['cartCreate'] ?? const {})['cart'] ?? const {}));
   }
 
   /// add line item to cart
@@ -76,19 +75,14 @@ class ShopifyCart with ShopifyError {
     }).toList();
     final MutationOptions addLineItem = MutationOptions(
       document: gql(addLineItemToCartMutation),
-      variables: {
-        'cartId': cartId,
-        'lines': lineInputs,
-        'country': ShopifyLocalization.countryCode
-      },
+      variables: {'cartId': cartId, 'lines': lineInputs, 'country': ShopifyLocalization.countryCode},
     );
     QueryResult result = await _graphQLClient!.mutate(addLineItem);
     checkForError(result, key: 'cartLinesAdd', errorKey: 'userErrors');
 
     log('added cart :${(result.data!['cartLinesAdd'] ?? const {})['cart']}');
 
-    return Cart.fromJson(
-        ((result.data!['cartLinesAdd'] ?? const {})['cart'] ?? const {}));
+    return Cart.fromJson(((result.data!['cartLinesAdd'] ?? const {})['cart'] ?? const {}));
   }
 
   /// remove line item from cart
@@ -98,17 +92,12 @@ class ShopifyCart with ShopifyError {
   }) async {
     final MutationOptions removeLineItem = MutationOptions(
       document: gql(removeLineItemFromCartMutation),
-      variables: {
-        'cartId': cartId,
-        'lineIds': lineIds,
-        'country': ShopifyLocalization.countryCode
-      },
+      variables: {'cartId': cartId, 'lineIds': lineIds, 'country': ShopifyLocalization.countryCode},
     );
     QueryResult result = await _graphQLClient!.mutate(removeLineItem);
     checkForError(result, key: 'cartLinesRemove', errorKey: 'userErrors');
 
-    return Cart.fromJson(
-        ((result.data!['cartLinesRemove'] ?? const {})['cart'] ?? const {}));
+    return Cart.fromJson(((result.data!['cartLinesRemove'] ?? const {})['cart'] ?? const {}));
   }
 
   /// update line items in cart
@@ -128,8 +117,7 @@ class ShopifyCart with ShopifyError {
     QueryResult result = await _graphQLClient!.mutate(updateLineItem);
     checkForError(result, key: 'cartLinesUpdate', errorKey: 'userErrors');
 
-    return Cart.fromJson(
-        ((result.data!['cartLinesUpdate'] ?? const {})['cart'] ?? const {}));
+    return Cart.fromJson(((result.data!['cartLinesUpdate'] ?? const {})['cart'] ?? const {}));
   }
 
   /// update note in cart
@@ -148,8 +136,7 @@ class ShopifyCart with ShopifyError {
     QueryResult result = await _graphQLClient!.mutate(updateNote);
     checkForError(result, key: 'cartNoteUpdate', errorKey: 'userErrors');
 
-    return Cart.fromJson(
-        ((result.data!['cartNoteUpdate'] ?? const {})['cart'] ?? const {}));
+    return Cart.fromJson(((result.data!['cartNoteUpdate'] ?? const {})['cart'] ?? const {}));
   }
 
   /// update cart discount codes
@@ -166,12 +153,9 @@ class ShopifyCart with ShopifyError {
       },
     );
     QueryResult result = await _graphQLClient!.mutate(updateDiscountCodes);
-    checkForError(result,
-        key: 'cartDiscountCodesUpdate', errorKey: 'userErrors');
+    checkForError(result, key: 'cartDiscountCodesUpdate', errorKey: 'userErrors');
 
-    return Cart.fromJson(
-        ((result.data!['cartDiscountCodesUpdate'] ?? const {})['cart'] ??
-            const {}));
+    return Cart.fromJson(((result.data!['cartDiscountCodesUpdate'] ?? const {})['cart'] ?? const {}));
   }
 
   /// update Buyer identity in cart
@@ -187,13 +171,11 @@ class ShopifyCart with ShopifyError {
           deliveryAddressPreferencesData.add({
             'deliveryAddress': pref.deliveryAddress?.toJson() ?? {},
           });
-        } else if (pref.customerAddressId != null &&
-            pref.deliveryAddress == null) {
+        } else if (pref.customerAddressId != null && pref.deliveryAddress == null) {
           deliveryAddressPreferencesData.add({
             'customerAddressId': pref.customerAddressId,
           });
-        } else if (pref.customerAddressId != null &&
-            pref.deliveryAddress != null) {
+        } else if (pref.customerAddressId != null && pref.deliveryAddress != null) {
           throw Exception(
             'Customer Address Id and Delivery Address cannot be set at the same time, please choose one',
           );
@@ -215,11 +197,8 @@ class ShopifyCart with ShopifyError {
       },
     );
     QueryResult result = await _graphQLClient!.mutate(updateBuyerIdentity);
-    checkForError(result,
-        key: 'cartBuyerIdentityUpdate', errorKey: 'userErrors');
+    checkForError(result, key: 'cartBuyerIdentityUpdate', errorKey: 'userErrors');
 
-    return Cart.fromJson(
-        ((result.data!['cartBuyerIdentityUpdate'] ?? const {})['cart'] ??
-            const {}));
+    return Cart.fromJson(((result.data!['cartBuyerIdentityUpdate'] ?? const {})['cart'] ?? const {}));
   }
 }

--- a/lib/shopify/src/shopify_checkout.dart
+++ b/lib/shopify/src/shopify_checkout.dart
@@ -101,8 +101,7 @@ class ShopifyCheckout with ShopifyError {
       variables: {
         'checkoutId': checkoutId,
         'input': {
-          if (allowPartialAddresses != null)
-            'allowPartialAddresses': allowPartialAddresses,
+          if (allowPartialAddresses != null) 'allowPartialAddresses': allowPartialAddresses,
           if (customAttributes != null)
             'customAttributes': [
               for (var entry in customAttributes.entries)
@@ -139,12 +138,9 @@ class ShopifyCheckout with ShopifyError {
     // });
     // final QueryResult result =
     //     await ShopifyConfig.graphQLClient!.query(_options);
-    final MutationOptions _options =
-        MutationOptions(document: gql(getAllOrdersQuery), variables: {
-      'accessToken': customerAccessToken,
-      'sortKey': sortKey.parseToString(),
-      'reverse': reverse
-    });
+    final MutationOptions _options = MutationOptions(
+        document: gql(getAllOrdersQuery),
+        variables: {'accessToken': customerAccessToken, 'sortKey': sortKey.parseToString(), 'reverse': reverse});
     QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(result);
     final ordersData = result.data!['customer']?['orders'];
@@ -198,10 +194,7 @@ class ShopifyCheckout with ShopifyError {
       errorKey: 'checkoutUserErrors',
     );
 
-    return Checkout.fromJson(
-        ((result.data!['checkoutShippingAddressUpdateV2'] ??
-                const {})['checkout'] ??
-            const {}));
+    return Checkout.fromJson(((result.data!['checkoutShippingAddressUpdateV2'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Updates the shipping address on given [checkoutId]
@@ -219,10 +212,7 @@ class ShopifyCheckout with ShopifyError {
       variables: {
         'checkoutId': checkoutId,
         "payment": {
-          "paymentAmount": {
-            "amount": price.amount,
-            "currencyCode": price.currencyCode
-          },
+          "paymentAmount": {"amount": price.amount, "currencyCode": price.currencyCode},
           "idempotencyKey": impotencyKey,
           "billingAddress": {
             "firstName": billingAddress.firstName,
@@ -244,22 +234,17 @@ class ShopifyCheckout with ShopifyError {
       key: 'checkoutCompleteWithTokenizedPaymentV2',
       errorKey: 'checkoutUserErrors',
     );
-    return (result.data!['checkoutCompleteWithTokenizedPaymentV2'] ??
-        const {})['payment']['id'];
+    return (result.data!['checkoutCompleteWithTokenizedPaymentV2'] ?? const {})['payment']['id'];
   }
 
   /// Helper method for transforming a list of variant ids into a List of Map which looks like this:
   ///
   /// [{"quantity":AMOUNT,"variantId":"YOUR_VARIANT_ID"}]
-  List<Map<String, dynamic>> transformVariantIdListIntoListOfMaps(
-      List<String> variantIdList) {
+  List<Map<String, dynamic>> transformVariantIdListIntoListOfMaps(List<String> variantIdList) {
     List<Map<String, dynamic>> lineItemList = [];
     for (var e in variantIdList) {
       if (lineItemList.indexWhere((test) => e == test['variantId']) == -1) {
-        lineItemList.add({
-          "quantity": variantIdList.where((id) => e == id).toList().length,
-          "variantId": e
-        });
+        lineItemList.add({"quantity": variantIdList.where((id) => e == id).toList().length, "variantId": e});
       }
     }
     return lineItemList;
@@ -284,9 +269,7 @@ class ShopifyCheckout with ShopifyError {
       errorKey: 'checkoutUserErrors',
     );
 
-    return Checkout.fromJson(
-        ((result.data!['checkoutEmailUpdateV2'] ?? const {})['checkout'] ??
-            const {}));
+    return Checkout.fromJson(((result.data!['checkoutEmailUpdateV2'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Associates the [Customer] that [customerAccessToken] belongs to, to the [Checkout] that [checkoutId] belongs to.
@@ -296,10 +279,7 @@ class ShopifyCheckout with ShopifyError {
   ) async {
     final MutationOptions _options = MutationOptions(
         document: gql(associateCustomer),
-        variables: {
-          'checkoutId': checkoutId,
-          'customerAccessToken': customerAccessToken
-        });
+        variables: {'checkoutId': checkoutId, 'customerAccessToken': customerAccessToken});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -312,9 +292,8 @@ class ShopifyCheckout with ShopifyError {
   Future<void> checkoutCustomerDisassociate(
     String checkoutId,
   ) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(checkoutCustomerDisassociateMutation),
-        variables: {'id': checkoutId});
+    final MutationOptions _options =
+        MutationOptions(document: gql(checkoutCustomerDisassociateMutation), variables: {'id': checkoutId});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -337,18 +316,15 @@ class ShopifyCheckout with ShopifyError {
       key: 'checkoutDiscountCodeApplyV2',
       errorKey: 'checkoutUserErrors',
     );
-    return Checkout.fromJson(((result.data?['checkoutDiscountCodeApplyV2'] ??
-            const {})['checkout'] ??
-        const {}));
+    return Checkout.fromJson(((result.data?['checkoutDiscountCodeApplyV2'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Removes the applied discount from the [Checkout] that [checkoutId] belongs to.
   Future<void> checkoutDiscountCodeRemove(
     String checkoutId,
   ) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(checkoutDiscountCodeRemoveMutation),
-        variables: {'checkoutId': checkoutId});
+    final MutationOptions _options =
+        MutationOptions(document: gql(checkoutDiscountCodeRemoveMutation), variables: {'checkoutId': checkoutId});
     QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -379,8 +355,7 @@ class ShopifyCheckout with ShopifyError {
     Address? shippingAddress,
     String? email,
   }) async {
-    final MutationOptions _options =
-        MutationOptions(document: gql(createCheckoutMutation), variables: {
+    final MutationOptions _options = MutationOptions(document: gql(createCheckoutMutation), variables: {
       'input': {
         'allowPartialAddresses': true,
         if (lineItems != null)
@@ -419,8 +394,7 @@ class ShopifyCheckout with ShopifyError {
       key: 'checkoutCreate',
       errorKey: 'checkoutUserErrors',
     );
-    return Checkout.fromJson(
-        ((result.data!['checkoutCreate'] ?? const {})['checkout'] ?? const {}));
+    return Checkout.fromJson(((result.data!['checkoutCreate'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Returns the [Checkout] that [checkoutId] belongs to after adding the [lineItems] to it.
@@ -428,24 +402,22 @@ class ShopifyCheckout with ShopifyError {
     required String checkoutId,
     required List<LineItem> lineItems,
   }) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(addLineItemsToCheckoutMutation),
-        variables: {
-          'checkoutId': checkoutId,
-          'lineItems': [
-            for (var lineItem in lineItems)
-              {
-                'variantId': lineItem.variantId,
-                'quantity': lineItem.quantity,
-                'customAttributes': lineItem.customAttributes
-                    .map((e) => {
-                          'key': e.key,
-                          'value': e.value,
-                        })
-                    .toList(),
-              }
-          ],
-        });
+    final MutationOptions _options = MutationOptions(document: gql(addLineItemsToCheckoutMutation), variables: {
+      'checkoutId': checkoutId,
+      'lineItems': [
+        for (var lineItem in lineItems)
+          {
+            'variantId': lineItem.variantId,
+            'quantity': lineItem.quantity,
+            'customAttributes': lineItem.customAttributes
+                .map((e) => {
+                      'key': e.key,
+                      'value': e.value,
+                    })
+                .toList(),
+          }
+      ],
+    });
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -453,9 +425,7 @@ class ShopifyCheckout with ShopifyError {
       errorKey: 'checkoutUserErrors',
     );
 
-    return Checkout.fromJson(
-        ((result.data!['checkoutLineItemsAdd'] ?? const {})['checkout'] ??
-            const {}));
+    return Checkout.fromJson(((result.data!['checkoutLineItemsAdd'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Returns the [Checkout] that [checkoutId] belongs to after updating the [lineItems] to it.
@@ -463,25 +433,23 @@ class ShopifyCheckout with ShopifyError {
     required String checkoutId,
     required List<LineItem> lineItems,
   }) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(updateLineItemsInCheckoutMutation),
-        variables: {
-          'checkoutId': checkoutId,
-          'lineItems': [
-            for (var lineItem in lineItems)
-              {
-                'id': lineItem.id,
-                'variantId': lineItem.variantId,
-                'quantity': lineItem.quantity,
-                'customAttributes': lineItem.customAttributes
-                    .map((e) => {
-                          'key': e.key,
-                          'value': e.value,
-                        })
-                    .toList(),
-              }
-          ],
-        });
+    final MutationOptions _options = MutationOptions(document: gql(updateLineItemsInCheckoutMutation), variables: {
+      'checkoutId': checkoutId,
+      'lineItems': [
+        for (var lineItem in lineItems)
+          {
+            'id': lineItem.id,
+            'variantId': lineItem.variantId,
+            'quantity': lineItem.quantity,
+            'customAttributes': lineItem.customAttributes
+                .map((e) => {
+                      'key': e.key,
+                      'value': e.value,
+                    })
+                .toList(),
+          }
+      ],
+    });
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -489,9 +457,7 @@ class ShopifyCheckout with ShopifyError {
       errorKey: 'checkoutUserErrors',
     );
 
-    return Checkout.fromJson(
-        ((result.data!['checkoutLineItemsUpdate'] ?? const {})['checkout'] ??
-            const {}));
+    return Checkout.fromJson(((result.data!['checkoutLineItemsUpdate'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Returns the [Checkout] that [checkoutId] belongs to after removing the [lineItems] from it.
@@ -499,12 +465,10 @@ class ShopifyCheckout with ShopifyError {
     required String checkoutId,
     required List<LineItem> lineItems,
   }) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(removeLineItemsFromCheckoutMutation),
-        variables: {
-          'checkoutId': checkoutId,
-          'lineItemIds': [for (var lineItem in lineItems) lineItem.id],
-        });
+    final MutationOptions _options = MutationOptions(document: gql(removeLineItemsFromCheckoutMutation), variables: {
+      'checkoutId': checkoutId,
+      'lineItemIds': [for (var lineItem in lineItems) lineItem.id],
+    });
 
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
@@ -513,9 +477,7 @@ class ShopifyCheckout with ShopifyError {
       errorKey: 'checkoutUserErrors',
     );
 
-    return Checkout.fromJson(
-        ((result.data!['checkoutLineItemsRemove'] ?? const {})['checkout'] ??
-            const {}));
+    return Checkout.fromJson(((result.data!['checkoutLineItemsRemove'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Removes the Gift card that [appliedGiftCardId] belongs to, from the [Checkout] that [checkoutId] belongs to.
@@ -525,10 +487,7 @@ class ShopifyCheckout with ShopifyError {
   ) async {
     final MutationOptions _options = MutationOptions(
         document: gql(checkoutGiftCardRemoveMutation),
-        variables: {
-          'appliedGiftCardId': appliedGiftCardId,
-          'checkoutId': checkoutId
-        });
+        variables: {'appliedGiftCardId': appliedGiftCardId, 'checkoutId': checkoutId});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -544,10 +503,7 @@ class ShopifyCheckout with ShopifyError {
   ) async {
     final MutationOptions _options = MutationOptions(
         document: gql(checkoutShippingLineUpdateMutation),
-        variables: {
-          'shippingRateHandle': shippingRateHandle,
-          'checkoutId': checkoutId
-        });
+        variables: {'shippingRateHandle': shippingRateHandle, 'checkoutId': checkoutId});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -555,9 +511,7 @@ class ShopifyCheckout with ShopifyError {
       errorKey: 'checkoutUserErrors',
     );
 
-    return Checkout.fromJson(
-        ((result.data!['checkoutShippingLineUpdate'] ?? const {})['checkout'] ??
-            const {}));
+    return Checkout.fromJson(((result.data!['checkoutShippingLineUpdate'] ?? const {})['checkout'] ?? const {}));
   }
 
   /// Complete [Checkout] without providing payment information.
@@ -565,9 +519,8 @@ class ShopifyCheckout with ShopifyError {
   Future<void> checkoutCompleteFree(
     String checkoutId,
   ) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(checkoutCompleteFreeMutation),
-        variables: {'checkoutId': checkoutId});
+    final MutationOptions _options =
+        MutationOptions(document: gql(checkoutCompleteFreeMutation), variables: {'checkoutId': checkoutId});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -630,8 +583,6 @@ class ShopifyCheckout with ShopifyError {
       errorKey: 'checkoutUserErrors',
     );
     return TokanizedCheckout.fromJson(
-        ((result.data!['checkoutCompleteWithTokenizedPaymentV3'] ??
-                const {})['payment'] ??
-            const {}));
+        ((result.data!['checkoutCompleteWithTokenizedPaymentV3'] ?? const {})['payment'] ?? const {}));
   }
 }

--- a/lib/shopify/src/shopify_custom.dart
+++ b/lib/shopify/src/shopify_custom.dart
@@ -27,9 +27,8 @@ class ShopifyCustom with ShopifyError {
       variables: variables,
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
-    final QueryResult result = adminAccess
-        ? await _graphQLClientAdmin!.query(_options)
-        : await _graphQLClient!.query(_options);
+    final QueryResult result =
+        adminAccess ? await _graphQLClientAdmin!.query(_options) : await _graphQLClient!.query(_options);
     checkForError(result);
     return result.data;
   }
@@ -48,9 +47,8 @@ class ShopifyCustom with ShopifyError {
       document: gql(gqlMutation),
       variables: variables,
     );
-    final QueryResult result = adminAccess
-        ? await _graphQLClientAdmin!.mutate(_options)
-        : await _graphQLClient!.mutate(_options);
+    final QueryResult result =
+        adminAccess ? await _graphQLClientAdmin!.mutate(_options) : await _graphQLClient!.mutate(_options);
     checkForError(result);
     return result.data;
   }

--- a/lib/shopify/src/shopify_customer.dart
+++ b/lib/shopify/src/shopify_customer.dart
@@ -33,22 +33,20 @@ class ShopifyCustomer with ShopifyError {
     required String customerAccessToken,
     required String id,
   }) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(customerAddressUpdateMutation),
-        variables: {
-          'address1': address1,
-          'address2': address2,
-          'company': company,
-          'city': city,
-          'country': country,
-          'firstName': firstName,
-          'lastName': lastName,
-          'phone': phone,
-          'province': province,
-          'zip': zip,
-          'customerAccessToken': customerAccessToken,
-          'id': id
-        });
+    final MutationOptions _options = MutationOptions(document: gql(customerAddressUpdateMutation), variables: {
+      'address1': address1,
+      'address2': address2,
+      'company': company,
+      'city': city,
+      'country': country,
+      'firstName': firstName,
+      'lastName': lastName,
+      'phone': phone,
+      'province': province,
+      'zip': zip,
+      'customerAccessToken': customerAccessToken,
+      'id': id
+    });
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -84,9 +82,8 @@ class ShopifyCustomer with ShopifyError {
 
     dataMap.forEach((k, v) => v != {} ? variableMap[k] = v : {});
 
-    final MutationOptions _options = MutationOptions(
-        document: gql(createValidMutationString(variableMap)),
-        variables: variableMap);
+    final MutationOptions _options =
+        MutationOptions(document: gql(createValidMutationString(variableMap)), variables: variableMap);
     QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -109,29 +106,26 @@ class ShopifyCustomer with ShopifyError {
     String? zip,
     String? customerAccessToken,
   }) async {
-    final MutationOptions _options = MutationOptions(
-        document: gql(customerAddressCreateMutation),
-        variables: {
-          'address1': address1,
-          'address2': address2,
-          'company': company,
-          'city': city,
-          'country': country,
-          'firstName': firstName,
-          'lastName': lastName,
-          'phone': phone,
-          'province': province,
-          'zip': zip,
-          'customerAccessToken': customerAccessToken,
-        });
+    final MutationOptions _options = MutationOptions(document: gql(customerAddressCreateMutation), variables: {
+      'address1': address1,
+      'address2': address2,
+      'company': company,
+      'city': city,
+      'country': country,
+      'firstName': firstName,
+      'lastName': lastName,
+      'phone': phone,
+      'province': province,
+      'zip': zip,
+      'customerAccessToken': customerAccessToken,
+    });
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
       key: 'customerAddressCreate',
       errorKey: 'customerUserErrors',
     );
-    return Address.fromJson(
-        (result.data!['customerAddressCreate']['customerAddress'] ?? {}));
+    return Address.fromJson((result.data!['customerAddressCreate']['customerAddress'] ?? {}));
   }
 
   /// Deletes the address associated with the [addressId] from the customer to which [customerAccessToken] belongs to.
@@ -143,10 +137,7 @@ class ShopifyCustomer with ShopifyError {
   }) async {
     final MutationOptions _options = MutationOptions(
         document: gql(customerAddressDeleteMutation),
-        variables: {
-          'customerAccessToken': customerAccessToken,
-          'id': addressId
-        });
+        variables: {'customerAccessToken': customerAccessToken, 'id': addressId});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,
@@ -162,10 +153,7 @@ class ShopifyCustomer with ShopifyError {
   }) async {
     final MutationOptions _options = MutationOptions(
         document: gql(customerDefaultAddressUpdateMutation),
-        variables: {
-          'customerAccessToken': customerAccessToken,
-          'addressId': addressId
-        });
+        variables: {'customerAccessToken': customerAccessToken, 'addressId': addressId});
     final QueryResult result = await _graphQLClient!.mutate(_options);
     checkForError(
       result,

--- a/lib/shopify/src/shopify_localization.dart
+++ b/lib/shopify/src/shopify_localization.dart
@@ -36,8 +36,7 @@ class ShopifyLocalization with ShopifyError {
   /// If none is provided, the general localization object is returned.
   /// It provides information regarding supported [Language]s,
   /// [Country]s and [Currencies] suuported by each country.
-  Future<Localization> getLocalization(
-      {String? countrycode, String? languageCode}) async {
+  Future<Localization> getLocalization({String? countrycode, String? languageCode}) async {
     WatchQueryOptions _options;
     _options = WatchQueryOptions(
       document: gql(getLocalizationQuery),
@@ -47,7 +46,6 @@ class ShopifyLocalization with ShopifyError {
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
 
-    return Localization.fromJson(
-        (result.data ?? const {})["localization"] ?? {});
+    return Localization.fromJson((result.data ?? const {})["localization"] ?? {});
   }
 }

--- a/lib/shopify/src/shopify_order.dart
+++ b/lib/shopify/src/shopify_order.dart
@@ -20,8 +20,7 @@ class ShopifyOrder with ShopifyError {
     SortKeyOrder sortKey = SortKeyOrder.PROCESSED_AT,
     bool reverse = true,
   }) async {
-    final MutationOptions _options =
-        MutationOptions(document: gql(getAllOrdersQuery), variables: {
+    final MutationOptions _options = MutationOptions(document: gql(getAllOrdersQuery), variables: {
       'accessToken': customerAccessToken,
       'sortKey': sortKey.parseToString(),
       'reverse': reverse,

--- a/lib/shopify/src/shopify_page.dart
+++ b/lib/shopify/src/shopify_page.dart
@@ -36,8 +36,7 @@ class ShopifyPage with ShopifyError {
     );
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
-    return (Pages.fromGraphJson((result.data ?? const {})["pages"] ?? const {}))
-        .pageList;
+    return (Pages.fromGraphJson((result.data ?? const {})["pages"] ?? const {})).pageList;
   }
 
   /// Returns a [Page].

--- a/lib/shopify/src/shopify_store.dart
+++ b/lib/shopify/src/shopify_store.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 
+import 'package:flutter/material.dart';
 import 'package:shopify_flutter/enums/enums.dart';
 import 'package:shopify_flutter/graphql_operations/storefront/queries/get_all_collections_optimized.dart';
 import 'package:shopify_flutter/graphql_operations/storefront/queries/get_all_products_from_collection_by_id.dart';
@@ -16,12 +17,12 @@ import 'package:shopify_flutter/graphql_operations/storefront/queries/search_pro
 import 'package:shopify_flutter/graphql_operations/storefront/queries/get_x_products_on_query_after_cursor.dart';
 import 'package:shopify_flutter/mixins/src/shopify_error.dart';
 import 'package:shopify_flutter/models/src/collection/collections/collections.dart';
+import 'package:shopify_flutter/models/src/product/metafield_identifier/metafield_identifier.dart';
 import 'package:shopify_flutter/models/src/product/product.dart';
 import 'package:shopify_flutter/models/src/product/products/products.dart';
 import 'package:shopify_flutter/models/src/shop/shop.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:shopify_flutter/shopify/src/shopify_localization.dart';
-
 import '../../graphql_operations/storefront/queries/get_featured_collections.dart';
 import '../../graphql_operations/storefront/queries/get_n_products.dart';
 import '../../graphql_operations/storefront/queries/get_products.dart';
@@ -42,6 +43,7 @@ class ShopifyStore with ShopifyError {
   /// Simply returns all Products from your Store.
   Future<List<Product>> getAllProducts({
     bool reverse = false,
+    List<MetafieldIdentifier>? metafields,
   }) async {
     List<Product> productList = [];
     Products tempProduct;
@@ -54,13 +56,13 @@ class ShopifyStore with ShopifyError {
           'cursor': cursor,
           'reverse': reverse,
           'country': ShopifyLocalization.countryCode,
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
         },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
       final QueryResult result = await _graphQLClient!.query(_options);
       checkForError(result);
-      tempProduct =
-          (Products.fromGraphJson((result.data ?? const {})["products"] ?? {}));
+      tempProduct = (Products.fromGraphJson((result.data ?? const {})["products"] ?? {}));
 
       productList += tempProduct.productList;
       cursor = productList.isNotEmpty ? productList.last.cursor : '';
@@ -72,9 +74,13 @@ class ShopifyStore with ShopifyError {
   ///
   /// Returns the first [limit] Products after the given [startCursor].
   /// [limit] has to be in the range of 0 and 250.
-  Future<List<Product>> getXProductsAfterCursor(int limit, String startCursor,
-      {bool reverse = false,
-      SortKeyProduct sortKeyProduct = SortKeyProduct.TITLE}) async {
+  Future<List<Product>> getXProductsAfterCursor(
+    int limit,
+    String startCursor, {
+    bool reverse = false,
+    SortKeyProduct sortKeyProduct = SortKeyProduct.TITLE,
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     List<Product> productList = [];
     Products tempProduct;
     String cursor = startCursor;
@@ -86,13 +92,13 @@ class ShopifyStore with ShopifyError {
         'reverse': reverse,
         'sortKey': sortKeyProduct.parseToString(),
         'country': ShopifyLocalization.countryCode,
+        'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
-    tempProduct =
-        (Products.fromGraphJson((result.data ?? const {})["products"] ?? {}));
+    tempProduct = (Products.fromGraphJson((result.data ?? const {})["products"] ?? {}));
     productList += tempProduct.productList;
     return productList;
   }
@@ -101,14 +107,16 @@ class ShopifyStore with ShopifyError {
   ///
   /// Returns the Products associated to the given id's in [idList]
   Future<List<Product>?> getProductsByIds(
-    List<String> idList,
-  ) async {
+    List<String> idList, {
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     List<Product>? productList = [];
     final QueryOptions _options = WatchQueryOptions(
       document: gql(getProductsByIdsQuery),
       variables: {
         'ids': idList,
         'country': ShopifyLocalization.countryCode,
+        'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
@@ -132,14 +140,13 @@ class ShopifyStore with ShopifyError {
   /// Returns Product.
   ///
   /// Returns Product by [handle]
-  Future<Product?> getProductByHandle(
-    String handle,
-  ) async {
+  Future<Product?> getProductByHandle(String handle, {List<MetafieldIdentifier>? metafields}) async {
     final QueryOptions _options = WatchQueryOptions(
       document: gql(getProductByHandleQuery),
       variables: {
         'handle': handle,
         'country': ShopifyLocalization.countryCode,
+        'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
@@ -167,9 +174,12 @@ class ShopifyStore with ShopifyError {
   ///  SortKey.PRICE,
   ///  SortKey.ID,
   ///  SortKey.RELEVANCE,
-  Future<List<Product>?> getNProducts(int n,
-      {bool? reverse,
-      SortKeyProduct sortKey = SortKeyProduct.PRODUCT_TYPE}) async {
+  Future<List<Product>?> getNProducts(
+    int n, {
+    bool? reverse,
+    SortKeyProduct sortKey = SortKeyProduct.PRODUCT_TYPE,
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     List<Product>? productList = [];
     final WatchQueryOptions _options = WatchQueryOptions(
       document: gql(getNProductsQuery),
@@ -177,39 +187,36 @@ class ShopifyStore with ShopifyError {
         'n': n,
         'sortKey': sortKey.parseToString(),
         'reverse': reverse,
-        'country': ShopifyLocalization.countryCode
+        'country': ShopifyLocalization.countryCode,
+        'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
-    productList =
-        (Products.fromGraphJson((result.data ?? const {})["products"] ?? {}))
-            .productList;
+    productList = (Products.fromGraphJson((result.data ?? const {})["products"] ?? {})).productList;
     return productList;
   }
 
   /// Returns a list of recommended [Product] by given id.
   Future<List<Product>?> getProductRecommendations(
-    String productId,
-  ) async {
+    String productId, {
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     try {
       final WatchQueryOptions _options = WatchQueryOptions(
         document: gql(getProductRecommendationsQuery),
         variables: {
           'id': productId,
           'country': ShopifyLocalization.countryCode,
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
         },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
       final QueryResult result = await _graphQLClient!.query(_options);
       checkForError(result);
-      var newResponse = List.generate(
-          result.data!['productRecommendations']?.length ?? 0,
-          (index) => {
-                "node":
-                    (result.data!['productRecommendations'] ?? const {})[index]
-              });
+      var newResponse = List.generate(result.data!['productRecommendations']?.length ?? 0,
+          (index) => {"node": (result.data!['productRecommendations'] ?? const {})[index]});
       var tempProducts = {"edges": newResponse};
       return Products.fromGraphJson(tempProducts).productList;
     } catch (e) {
@@ -220,18 +227,22 @@ class ShopifyStore with ShopifyError {
 
   /// Returns a List of [Collection]
   Future<List<Collection>?> getCollectionsByIds(
-    List<String> idList,
-  ) async {
+    List<String> idList, {
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     try {
       final WatchQueryOptions _options = WatchQueryOptions(
         document: gql(getCollectionsByIdsQuery),
-        variables: {'ids': idList},
+        variables: {
+          'ids': idList,
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
+        },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
       final QueryResult result = await _graphQLClient!.query(_options);
       checkForError(result);
-      var newResponse = List.generate(result.data!['nodes']?.length ?? 0,
-          (index) => {"node": (result.data!['nodes'] ?? const {})[index]});
+      var newResponse = List.generate(
+          result.data!['nodes']?.length ?? 0, (index) => {"node": (result.data!['nodes'] ?? const {})[index]});
       var tempCollection = {"edges": newResponse};
       return Collections.fromGraphJson(tempCollection).collectionList;
     } catch (e) {
@@ -254,21 +265,22 @@ class ShopifyStore with ShopifyError {
   /// Returns a collection by handle.
   @Deprecated('Use [getCollectionById]')
   Future<Collection> getCollectionByHandle(
-    String collectionName,
-  ) async {
+    String collectionName, {
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     try {
       final WatchQueryOptions _options = WatchQueryOptions(
         document: gql(getFeaturedCollectionQuery),
         variables: {
           'query': collectionName,
           'country': ShopifyLocalization.countryCode,
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
         },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
       final QueryResult result = await _graphQLClient!.query(_options);
       checkForError(result);
-      return Collections.fromGraphJson(result.data!['collections'])
-          .collectionList[0];
+      return Collections.fromGraphJson(result.data!['collections']).collectionList[0];
     } catch (e) {
       log(e.toString());
     }
@@ -276,12 +288,16 @@ class ShopifyStore with ShopifyError {
   }
 
   /// Returns a collection by id.
-  Future<Collection?> getCollectionById(String collectionId) async {
+  Future<Collection?> getCollectionById(
+    String collectionId, {
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     try {
       final WatchQueryOptions _options = WatchQueryOptions(
         document: gql(getCollectionsByIdsQuery),
         variables: {
           'ids': [collectionId],
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
         },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
@@ -297,9 +313,11 @@ class ShopifyStore with ShopifyError {
   /// Returns all available collections.
   ///
   /// Tip: When editing Collections you can choose on which channel or app you want to make them available.
-  Future<List<Collection>> getAllCollections(
-      {SortKeyCollection sortKeyCollection = SortKeyCollection.UPDATED_AT,
-      bool reverse = false}) async {
+  Future<List<Collection>> getAllCollections({
+    SortKeyCollection sortKeyCollection = SortKeyCollection.UPDATED_AT,
+    bool reverse = false,
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     List<Collection> collectionList = [];
     Collections tempCollection;
     String? cursor;
@@ -310,14 +328,15 @@ class ShopifyStore with ShopifyError {
         variables: {
           'cursor': cursor,
           'sortKey': sortKeyCollection.parseToString(),
-          'reverse': reverse
+          'reverse': reverse,
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
         },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
       final QueryResult result = await _graphQLClient!.query(_options);
+      debugPrint('result: ${result.data.toString()}');
       checkForError(result);
-      tempCollection = (Collections.fromGraphJson(
-          (result.data ?? const {})['collections'] ?? {}));
+      tempCollection = (Collections.fromGraphJson((result.data ?? const {})['collections'] ?? {}));
       collectionList.addAll(tempCollection.collectionList);
       cursor = collectionList.isNotEmpty ? collectionList.last.cursor : '';
     } while ((tempCollection.hasNextPage == true));
@@ -330,10 +349,11 @@ class ShopifyStore with ShopifyError {
   Future<List<Collection>?> getXCollectionsAndNProductsSorted(
     int n,
     int x, {
-    SortKeyProductCollection sortKeyProductCollection =
-        SortKeyProductCollection.CREATED,
+    SortKeyProductCollection sortKeyProductCollection = SortKeyProductCollection.CREATED,
     SortKeyCollection sortKeyCollection = SortKeyCollection.UPDATED_AT,
     bool reverse = false,
+    List<MetafieldIdentifier>? productMetafields,
+    List<MetafieldIdentifier>? collectionMetafields,
   }) async {
     List<Collection>? collectionList;
     String? cursor;
@@ -348,23 +368,26 @@ class ShopifyStore with ShopifyError {
         'x': x,
         'n': n,
         'country': ShopifyLocalization.countryCode,
+        'productMetafields': productMetafields != null ? productMetafields.map((e) => e.toJson()).toList() : [],
+        'collectionMetafields':
+            collectionMetafields != null ? collectionMetafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
     final QueryResult result = await _graphQLClient!.query(_options);
     checkForError(result);
-    collectionList = (Collections.fromGraphJson(
-            (result.data ?? const {})['collections'] ?? {}))
-        .collectionList;
+    collectionList = (Collections.fromGraphJson((result.data ?? const {})['collections'] ?? {})).collectionList;
     return collectionList;
   }
 
   /// Returns a List of [Product].
   ///
   /// Returns all Products from the [Collection] with the [id].
-  Future<List<Product>> getAllProductsFromCollectionById(String id,
-      {SortKeyProductCollection sortKeyProductCollection =
-          SortKeyProductCollection.CREATED}) async {
+  Future<List<Product>> getAllProductsFromCollectionById(
+    String id, {
+    SortKeyProductCollection sortKeyProductCollection = SortKeyProductCollection.CREATED,
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     String? cursor;
     List<Product> productList = [];
     Collection collection;
@@ -377,13 +400,13 @@ class ShopifyStore with ShopifyError {
           'cursor': cursor,
           'sortKey': sortKeyProductCollection.parseToString(),
           'country': ShopifyLocalization.countryCode,
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
         },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
       final QueryResult result = await _graphQLClient!.query(_options);
       checkForError(result);
-      productList
-          .addAll(Collection.fromGraphJson(result.data!).products.productList);
+      productList.addAll(Collection.fromGraphJson(result.data!).products.productList);
       collection = (Collection.fromGraphJson(result.data!));
       cursor = productList.isNotEmpty ? productList.last.cursor : '';
     } while (collection.products.hasNextPage == true);
@@ -415,6 +438,7 @@ class ShopifyStore with ShopifyError {
     SortKeyProductCollection sortKey = SortKeyProductCollection.BEST_SELLING,
     bool reverse = false,
     Map<String, dynamic>? filters,
+    List<MetafieldIdentifier>? metafields,
   }) async {
     String? cursor = startCursor;
     final WatchQueryOptions _options = WatchQueryOptions(
@@ -427,6 +451,7 @@ class ShopifyStore with ShopifyError {
         'reverse': reverse,
         'filters': [if (filters != null) filters],
         'country': ShopifyLocalization.countryCode,
+        'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
@@ -447,6 +472,7 @@ class ShopifyStore with ShopifyError {
     SearchSortKeys sortKey = SearchSortKeys.RELEVANCE,
     bool reverse = false,
     Map<String, dynamic>? filters,
+    List<MetafieldIdentifier>? metafields,
   }) async {
     String? cursor = startCursor;
     final WatchQueryOptions _options = WatchQueryOptions(
@@ -459,6 +485,7 @@ class ShopifyStore with ShopifyError {
         'reverse': reverse,
         'filters': [if (filters != null) filters],
         'country': ShopifyLocalization.countryCode,
+        'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
@@ -470,8 +497,13 @@ class ShopifyStore with ShopifyError {
   /// Returns a List of [Product].
   ///
   /// Gets all [Product] from a [query] search sorted by [sortKey].
-  Future<List<Product>> getAllProductsOnQuery(String cursor, String query,
-      {SortKeyProduct? sortKey, bool reverse = false}) async {
+  Future<List<Product>> getAllProductsOnQuery(
+    String cursor,
+    String query, {
+    SortKeyProduct? sortKey,
+    bool reverse = false,
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     String? cursor;
     List<Product> productList = [];
     Products products;
@@ -485,15 +517,14 @@ class ShopifyStore with ShopifyError {
           'query': query,
           'reverse': reverse,
           'country': ShopifyLocalization.countryCode,
+          'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
         },
         fetchPolicy: ShopifyConfig.fetchPolicy,
       );
       final QueryResult result = await _graphQLClient!.query(_options);
       checkForError(result);
-      productList.addAll(
-          (Products.fromGraphJson((result.data!)['products'])).productList);
-      products =
-          (Products.fromGraphJson((result.data ?? const {})['products']));
+      productList.addAll((Products.fromGraphJson((result.data!)['products'])).productList);
+      products = (Products.fromGraphJson((result.data ?? const {})['products']));
       cursor = productList.isNotEmpty ? productList.last.cursor : '';
     } while (products.hasNextPage == true);
     return productList;
@@ -503,8 +534,13 @@ class ShopifyStore with ShopifyError {
   ///
   /// Gets [limit] amount of [Product] from the [query] search, sorted by [sortKey].
   Future<List<Product>?> getXProductsOnQueryAfterCursor(
-      String query, int limit, String? cursor,
-      {SortKeyProduct? sortKey, bool reverse = false}) async {
+    String query,
+    int limit,
+    String? cursor, {
+    SortKeyProduct? sortKey,
+    bool reverse = false,
+    List<MetafieldIdentifier>? metafields,
+  }) async {
     final WatchQueryOptions _options = WatchQueryOptions(
       document: gql(getXProductsOnQueryAfterCursorQuery),
       variables: {
@@ -514,13 +550,12 @@ class ShopifyStore with ShopifyError {
         'query': query,
         'reverse': reverse,
         'country': ShopifyLocalization.countryCode,
+        'metafields': metafields != null ? metafields.map((e) => e.toJson()).toList() : [],
       },
       fetchPolicy: ShopifyConfig.fetchPolicy,
     );
-    final QueryResult result =
-        await ShopifyConfig.graphQLClient!.query(_options);
+    final QueryResult result = await ShopifyConfig.graphQLClient!.query(_options);
     checkForError(result);
-    return Products.fromGraphJson((result.data ?? const {})['products'])
-        .productList;
+    return Products.fromGraphJson((result.data ?? const {})['products']).productList;
   }
 }


### PR DESCRIPTION
as discussed in [Issue 111](https://github.com/imsujan276/shopify_flutter/issues/111), here is my pull request that adds metafield support to all all queries related to products and collections.

This adds an optional list of metafield identifiers on these functions, which as passed to the query, then parsed in the fromGraphJson inside the model classes.

Tested extensively against my store, and has worked great.