### PR TITLE
Bugfix: Missing $ in mutation

### DIFF
--- a/lib/graphql_operations/storefront/mutations/cart/cart_attributes_update_mutation.dart
+++ b/lib/graphql_operations/storefront/mutations/cart/cart_attributes_update_mutation.dart
@@ -1,6 +1,6 @@
 /// mutation to update cart attributes
 const String updateCartAttributesMutation = r'''
-mutation cartAttributesUpdate($cartId: ID!, attributes: [AttributeInput!]!, $country: CountryCode)  @inContext(country: $country) {
+mutation cartAttributesUpdate($cartId: ID!, $attributes: [AttributeInput!]!, $country: CountryCode)  @inContext(country: $country) {
   cartAttributesUpdate(attributes: $attributes, cartId: $cartId) {
     cart {
       id
@@ -236,14 +236,14 @@ mutation cartAttributesUpdate($cartId: ID!, attributes: [AttributeInput!]!, $cou
                               }
                               recurringDeliveries
                             }
-                          }   
+                          }
                 }
                 product {
                   options(first: 5) {
                       id
                       name
                       values
-                      } 
+                      }
                   variants(first: 250) {
                     edges {
                       node {


### PR DESCRIPTION
The attributes parameter in the updateCartAttributesMutation string was missing a needed dollarsign in order to work.

I have added it and tested that it worked.

I was working to add this into the repository as well, as it is a much-needed feature for us to customize checkout flow for my app users, so I am very grateful to Sujan for the add.