### PR TITLE
fix deliveryAddressInputToJson

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,15 +5,15 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   alerter:
     dependency: "direct main"
     description:
@@ -26,10 +26,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   args:
     dependency: transitive
     description:
@@ -138,10 +138,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   connectivity_plus:
     dependency: transitive
     description:
@@ -585,18 +585,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -891,12 +891,12 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.5.6"
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -941,10 +941,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -957,10 +957,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   synchronized:
     dependency: transitive
     description:
@@ -981,10 +981,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -1141,10 +1141,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   wakelock_plus:
     dependency: transitive
     description:

--- a/lib/models/src/cart/inputs/delivery_address_input/delivery_address_input.g.dart
+++ b/lib/models/src/cart/inputs/delivery_address_input/delivery_address_input.g.dart
@@ -19,6 +19,8 @@ _$DeliveryAddressInputImpl _$$DeliveryAddressInputImplFromJson(
 Map<String, dynamic> _$$DeliveryAddressInputImplToJson(
         _$DeliveryAddressInputImpl instance) =>
     <String, dynamic>{
-      'customerAddressId': instance.customerAddressId,
-      'deliveryAddress': instance.deliveryAddress?.toJson(),
+      if (instance.customerAddressId != null)
+        'customerAddressId': instance.customerAddressId,
+      if (instance.deliveryAddress != null)
+        'deliveryAddress': instance.deliveryAddress!.toJson(),
     };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,13 @@
 name: shopify_flutter
-description: A Flutter package to seamlessly connect your Shopify store with your app.
-version: 2.6.0
-repository: https://github.com/imsujan276/shopify_flutter
-issue_tracker: https://github.com/imsujan276/shopify_flutter/issues
+description: A Fork of shopify_flutter
+version: 1.0.0
+repository: https://github.com/ngabovictor/shopify_flutter_plus
+issue_tracker: https://github.com/ngabovictor/shopify_flutter_plus/issues
 
 tags:
   - shopify
   - shopify_flutter
+  - shopify_flutter_plus
 
 platforms:
   android:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,12 @@
 name: shopify_flutter
-description: A Fork of shopify_flutter
-version: 1.0.0
-repository: https://github.com/ngabovictor/shopify_flutter_plus
-issue_tracker: https://github.com/ngabovictor/shopify_flutter_plus/issues
+description: A Flutter package to seamlessly connect your Shopify store with your app.
+version: 2.6.0
+repository: https://github.com/imsujan276/shopify_flutter
+issue_tracker: https://github.com/imsujan276/shopify_flutter/issues
 
 tags:
   - shopify
   - shopify_flutter
-  - shopify_flutter_plus
 
 platforms:
   android:


### PR DESCRIPTION
Problem: DeliveryAddressInput toJson was defaulting both `customerAddressId` and `deliveryAddress` to either missing, which causes the Shopify api to reject the request as both values are present while it expects one of those.

Fix: omitted whichever is null during serialization