### PR TITLE
feat: allow injecting a custom GraphQLCache for Storefront/Admin clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.8.0
+* Added `cache` and `adminCache` optional parameters to `ShopifyConfig.setConfig`, allowing callers to inject a custom `GraphQLCache` (e.g. backed by `HiveStore` for disk persistence) for the Storefront and Admin API clients. Defaults preserve the previous in-memory behaviour.
+
 # 2.7.0
 * Added category information in all product related gql.
 * Updated example to show the product category

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ void main() {
 
      // Store locale | default : en
     language: 'en',
+
+    // optional | default: in-memory GraphQLCache()
+    // Inject a custom GraphQLCache for the Storefront client (e.g. disk-backed
+    // via HiveStore from graphql_flutter).
+    // cache: GraphQLCache(store: await HiveStore.open()),
+
+    // optional | default: in-memory GraphQLCache()
+    // Inject a custom GraphQLCache for the Admin client.
+    // adminCache: GraphQLCache(store: await HiveStore.open(boxName: 'admin')),
   );
   
   runApp(MyApp());
@@ -46,6 +55,8 @@ If you are not using that function, you may not need to provide it.
 > `storefrontApiVersion` default vesion is set to '2024-07'
 
 > `language` defaults to 'en'. It is the default locale/language of the store. Only takes effect if the store supports provided language code.
+
+> `cache` / `adminCache` let you supply a `GraphQLCache` from `graphql_flutter` so query results can be persisted to disk (e.g. via `HiveStore`) and survive app restarts. When omitted, fresh in-memory caches are created as before.
 
 <hr>
 

--- a/lib/shopify_config.dart
+++ b/lib/shopify_config.dart
@@ -88,6 +88,13 @@ class ShopifyConfig {
   ///
   /// [countryCode] is optional, but defaults to null.
   /// Used to change currency units. eg: "US", "NP", "JP" etc. Only takes effect if the store supports provided currency.
+  ///
+  /// [cache] is optional. Inject a custom [GraphQLCache] (e.g. backed by
+  /// `HiveStore` for disk persistence) for the Storefront API client.
+  /// Defaults to a new in-memory [GraphQLCache] when omitted.
+  ///
+  /// [adminCache] is optional. Inject a custom [GraphQLCache] for the Admin
+  /// API client. Defaults to a new in-memory [GraphQLCache] when omitted.
   static void setConfig({
     required String storefrontAccessToken,
     required String storeUrl,
@@ -95,6 +102,8 @@ class ShopifyConfig {
     String storefrontApiVersion = "2024-07",
     CachePolicy? cachePolicy,
     String? language,
+    GraphQLCache? cache,
+    GraphQLCache? adminCache,
   }) {
     _storefrontAccessToken = storefrontAccessToken;
     _adminAccessToken = adminAccessToken;
@@ -109,7 +118,7 @@ class ShopifyConfig {
           'Accept-Language': language ?? 'en',
         },
       ),
-      cache: GraphQLCache(),
+      cache: cache ?? GraphQLCache(),
     );
 
     _graphQLClientAdmin = _adminAccessToken == null
@@ -122,7 +131,7 @@ class ShopifyConfig {
                 'Accept-Language': language ?? 'en',
               },
             ),
-            cache: GraphQLCache(),
+            cache: adminCache ?? GraphQLCache(),
           );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shopify_flutter
 description: A Flutter package to seamlessly connect your Shopify store with your app.
-version: 2.7.0
+version: 2.8.0
 repository: https://github.com/imsujan276/shopify_flutter
 issue_tracker: https://github.com/imsujan276/shopify_flutter/issues
 


### PR DESCRIPTION
## Summary

`ShopifyConfig.setConfig` currently constructs the Storefront and Admin `GraphQLClient`s with a hard-coded `GraphQLCache()` (in-memory, default `InMemoryStore`). There is no way for an application to provide a different cache implementation, so GraphQL responses cannot be persisted across app restarts even when `cachePolicy: CachePolicy.cacheAndNetwork` is configured.

This PR adds two optional parameters to `setConfig`:

- `GraphQLCache? cache` — used for the Storefront client.
- `GraphQLCache? adminCache` — used for the Admin client.

Both default to `null`. When omitted, the previous behaviour is preserved exactly: a fresh `GraphQLCache()` is created internally, just like before. Existing callers do not need any changes.

## Why

We are running a Flutter app on top of `shopify_flutter` and want to persist Storefront query results to disk so that product/collection data is available immediately on cold start, before the network request returns. With the current API this is impossible without forking the package, because `_graphQLClient` is private and there is no hook for swapping the cache.

Allowing the caller to pass a `GraphQLCache` solves this in a fully backwards-compatible way: callers who do not care simply keep using the defaults, and callers who want disk persistence can pass `GraphQLCache(store: HiveStore())` (or any other `Store` implementation).

## Example

```dart
import 'package:graphql_flutter/graphql_flutter.dart';
import 'package:shopify_flutter/shopify_flutter.dart';

Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();
  await initHiveForFlutter();

  ShopifyConfig.setConfig(
    storefrontAccessToken: '*****',
    storeUrl: '*****.myshopify.com',
    cachePolicy: CachePolicy.cacheFirst,
    cache: GraphQLCache(store: HiveStore()),
  );

  runApp(const MyApp());
}
```

## Changes

- `lib/shopify_config.dart`: add `cache` and `adminCache` optional named parameters to `setConfig`. Each falls back to `GraphQLCache()` when `null`.
- `README.md`: document the new parameters and show a `HiveStore` example.
- `CHANGELOG.md`: bump to `2.8.0` and describe the change.
- `pubspec.yaml`: bump version to `2.8.0`.

## Backwards compatibility

- The new parameters are optional and default to `null`.
- When both are `null`, `setConfig` produces the same `GraphQLClient` instances it did before this PR (`GraphQLCache()` per client).
- No public types, getters, or method signatures are removed or renamed.
- Callers who never set `cache`/`adminCache` are unaffected.

## Test plan

- [x] `dart analyze` on the package: clean.
- [x] Wired the fork into a real Flutter app via `git:` override and confirmed `melos bootstrap` + `dart analyze` pass with the new parameters.
- [x] Verified that omitting `cache`/`adminCache` keeps the existing behaviour (the previous `GraphQLCache()` fallback path is hit).
- [ ] Manual smoke test on device with `GraphQLCache(store: HiveStore())` injected — owner of the fork is running this; results to be added as a follow-up comment.

Happy to adjust naming (e.g. `storefrontCache` / `adminCache`) or split into two PRs if you prefer.