### PR TITLE
Pass queryRequestTimeout to GraphQLClient (fixes #135)

### DIFF
--- a/lib/shopify_config.dart
+++ b/lib/shopify_config.dart
@@ -95,6 +95,11 @@ class ShopifyConfig {
   ///
   /// [adminCache] is optional. Inject a custom [GraphQLCache] for the Admin
   /// API client. Defaults to a new in-memory [GraphQLCache] when omitted.
+  ///
+  /// [queryRequestTimeout] overrides the per-request timeout on the underlying `graphql`
+  /// package, which otherwise applies a 5 s default that frequently trips on mobile
+  /// networks and can surface as a "Future already completed" crash when a late HTTP
+  /// response arrives after the timeout has fired. Pass `null` to disable the timeout.
   static void setConfig({
     required String storefrontAccessToken,
     required String storeUrl,
@@ -104,6 +109,7 @@ class ShopifyConfig {
     String? language,
     GraphQLCache? storefrontCache,
     GraphQLCache? adminCache,
+    Duration? queryRequestTimeout = const Duration(seconds: 30),
   }) {
     _storefrontAccessToken = storefrontAccessToken;
     _adminAccessToken = adminAccessToken;
@@ -119,6 +125,7 @@ class ShopifyConfig {
         },
       ),
       cache: storefrontCache ?? GraphQLCache(),
+      queryRequestTimeout: queryRequestTimeout,
     );
 
     _graphQLClientAdmin = _adminAccessToken == null
@@ -132,6 +139,7 @@ class ShopifyConfig {
               },
             ),
             cache: adminCache ?? GraphQLCache(),
+            queryRequestTimeout: queryRequestTimeout,
           );
   }
 }


### PR DESCRIPTION
Expose a queryRequestTimeout parameter on ShopifyConfig.setConfig and forward it to both the Storefront and Admin GraphQLClient instances.

Default raised from graphql's built-in 5 s to 30 s, which matches real-world Storefront/Admin latency on mobile networks. Pass null to disable the per-request timeout entirely.

The 5 s default caused frequent "Future already completed" crashes on mobile when a late HTTP response arrived after the timeout fired; see upstream graphql query_manager.dart:285 for the unguarded completer.complete that triggers the StateError.