### PR TITLE
Fix cartDiscountCodesUpdate $discountCodes nullability for newer Storefront API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.8.1+1 (qeepcologne fork)
+* Fix Shopify-side validation error `Nullability mismatch on variable $discountCodes and argument discountCodes ([String!] / [String!]!)` from `ShopifyCart.updateCartDiscountCodes`: the `cartDiscountCodesUpdate` mutation declared `$discountCodes: [String!]` but Shopify's Storefront schema requires `[String!]!`. Promoted the variable to a non-null list.
+
 # 2.8.1
 * Added `queryRequestTimeout` to `ShopifyConfig.setConfig` to set the GraphQL query timeout. `GraphQLClient` default timeout of 5s causes issue on late HTTP requests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.8.1+1 (qeepcologne fork)
-* Fix Shopify-side validation error `Nullability mismatch on variable $discountCodes and argument discountCodes ([String!] / [String!]!)` from `ShopifyCart.updateCartDiscountCodes`: the `cartDiscountCodesUpdate` mutation declared `$discountCodes: [String!]` but Shopify's Storefront schema requires `[String!]!`. Promoted the variable to a non-null list.
+* Fix Shopify-side validation error `Nullability mismatch on variable $discountCodes and argument discountCodes ([String!] / [String!]!)` from `ShopifyCart.updateCartDiscountCodes` against newer Storefront API versions (e.g. `2026-01`) that promoted the `cartDiscountCodesUpdate` argument from `[String!]` to `[String!]!`. The SDK's mutation document still declared the variable as the older nullable type, so the server rejected the request. Promoted the variable to `[String!]!`. Per the GraphQL spec ("All Variable Usages Are Allowed"), a non-null variable is also valid for the older nullable argument shape, so this change is forward- and backward-compatible across Storefront API versions; the Dart caller signature (`required List<String> discountCodes`) already enforces non-null.
 
 # 2.8.1
 * Added `queryRequestTimeout` to `ShopifyConfig.setConfig` to set the GraphQL query timeout. `GraphQLClient` default timeout of 5s causes issue on late HTTP requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.8.2 (qeepcologne fork)
+# 2.8.2
 * Fix Shopify-side validation error `Nullability mismatch on variable $discountCodes and argument discountCodes ([String!] / [String!]!)` from `ShopifyCart.updateCartDiscountCodes` against newer Storefront API versions (e.g. `2026-01`) that promoted the `cartDiscountCodesUpdate` argument from `[String!]` to `[String!]!`. The SDK's mutation document still declared the variable as the older nullable type, so the server rejected the request. Promoted the variable to `[String!]!`. Per the GraphQL spec ("All Variable Usages Are Allowed"), a non-null variable is also valid for the older nullable argument shape, so this change is forward- and backward-compatible across Storefront API versions; the Dart caller signature (`required List<String> discountCodes`) already enforces non-null.
 
 # 2.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.8.1+1 (qeepcologne fork)
+# 2.8.2 (qeepcologne fork)
 * Fix Shopify-side validation error `Nullability mismatch on variable $discountCodes and argument discountCodes ([String!] / [String!]!)` from `ShopifyCart.updateCartDiscountCodes` against newer Storefront API versions (e.g. `2026-01`) that promoted the `cartDiscountCodesUpdate` argument from `[String!]` to `[String!]!`. The SDK's mutation document still declared the variable as the older nullable type, so the server rejected the request. Promoted the variable to `[String!]!`. Per the GraphQL spec ("All Variable Usages Are Allowed"), a non-null variable is also valid for the older nullable argument shape, so this change is forward- and backward-compatible across Storefront API versions; the Dart caller signature (`required List<String> discountCodes`) already enforces non-null.
 
 # 2.8.1

--- a/lib/graphql_operations/storefront/mutations/cart/cart_discount_code_update_mutation.dart
+++ b/lib/graphql_operations/storefront/mutations/cart/cart_discount_code_update_mutation.dart
@@ -1,6 +1,6 @@
 /// mutation to update cart discount codes
 const String updateCartDiscountCodesMutation = r'''
-mutation cartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!], $country: CountryCode, $reverse: Boolean!)  @inContext(country: $country) {
+mutation cartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!, $country: CountryCode, $reverse: Boolean!)  @inContext(country: $country) {
   cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
     cart {
       id

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shopify_flutter
 description: A Flutter package to seamlessly connect your Shopify store with your app.
-version: 2.8.1
+version: 2.8.1+1
 repository: https://github.com/imsujan276/shopify_flutter
 issue_tracker: https://github.com/imsujan276/shopify_flutter/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shopify_flutter
 description: A Flutter package to seamlessly connect your Shopify store with your app.
-version: 2.8.1+1
+version: 2.8.2
 repository: https://github.com/imsujan276/shopify_flutter
 issue_tracker: https://github.com/imsujan276/shopify_flutter/issues
 


### PR DESCRIPTION
## Summary

- Promote the `\$discountCodes` variable in the `cartDiscountCodesUpdate` mutation document from `[String!]` to `[String!]!`.
- Bumps the package version to `2.8.2`.

## Why

Newer Shopify Storefront API versions (e.g. \`2026-01\` and later) promoted the \`cartDiscountCodesUpdate\` mutation's \`discountCodes\` argument from \`[String!]\` to \`[String!]!\`. The SDK's mutation document still declares the variable as the older nullable type, so Shopify rejects the request with:

\`\`\`
Nullability mismatch on variable \$discountCodes and argument discountCodes ([String!] / [String!]!)
\`\`\`

Apps pinning a recent \`storefrontApiVersion\` can't apply discount codes via \`ShopifyCart.updateCartDiscountCodes\` until this is fixed.

## Why this is safe across API versions

Per the GraphQL spec, [§5.8.5 "All Variable Usages Are Allowed"](https://spec.graphql.org/October2021/#sec-All-Variable-Usages-Are-Allowed):

| variable type | argument type | allowed? |
|---|---|---|
| \`[String!]\` | \`[String!]\` | ✓ |
| \`[String!]\` | \`[String!]!\` | ✗ — server error we're hitting |
| \`[String!]!\` | \`[String!]\` | ✓ — non-null is stricter, valid for nullable position |
| \`[String!]!\` | \`[String!]!\` | ✓ |

A non-null variable is universally valid against both shapes, so the fix is forward- *and* backward-compatible — apps on older Storefront API versions where the argument is still nullable continue to work without change.

The Dart caller signature (\`required List<String> discountCodes\` in \`ShopifyCart.updateCartDiscountCodes\`) already enforces non-null, so no caller can pass \`null\` today — there's no behavior change for callers either.

## Test plan

- [ ] Run \`example/\` against a store on Storefront API \`2026-01\` or newer: \`updateCartDiscountCodes\` succeeds where it previously errored.
- [ ] Run \`example/\` against a store on the SDK's default \`2024-07\`: \`updateCartDiscountCodes\` still succeeds (non-null variable is valid for the older nullable argument).