### PR TITLE
Add opt-in cartDiscountCodesUpdate warnings (errorCode/errorMessage on CartDiscountCode)

### DIFF
--- a/lib/graphql_operations/storefront/mutations/cart/cart_discount_code_update_mutation.dart
+++ b/lib/graphql_operations/storefront/mutations/cart/cart_discount_code_update_mutation.dart
@@ -1,5 +1,6 @@
-/// mutation to update cart discount codes
-const String updateCartDiscountCodesMutation = r'''
+/// head of the cart discount codes mutation (everything up to and including userErrors);
+/// assembled with the optional warnings fragment by [updateCartDiscountCodesMutation].
+const String _updateCartDiscountCodesHead = r'''
 mutation cartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!, $country: CountryCode, $reverse: Boolean!)  @inContext(country: $country) {
   cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
     cart {
@@ -398,6 +399,27 @@ mutation cartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!, $coun
       field
       message
     }
+''';
+
+/// optional payload-level warnings (CartWarningCode + localized message) explaining why a discount
+/// code is not applicable; only included when the caller opts in (requires a Storefront API version
+/// that supports cartDiscountCodesUpdate.warnings).
+const String _updateCartDiscountCodesWarnings = r'''
+    warnings {
+      code
+      message
+      target
+    }
+''';
+
+const String _updateCartDiscountCodesTail = r'''
   }
 }
 ''';
+
+/// mutation to update cart discount codes. [includeWarnings] appends the payload-level `warnings`
+/// field; off by default so the query is unchanged from upstream for callers on older API versions.
+String updateCartDiscountCodesMutation({bool includeWarnings = false}) =>
+    _updateCartDiscountCodesHead +
+    (includeWarnings ? _updateCartDiscountCodesWarnings : '') +
+    _updateCartDiscountCodesTail;

--- a/lib/models/src/cart/cart_dicount_code/cart_discount_code.dart
+++ b/lib/models/src/cart/cart_dicount_code/cart_discount_code.dart
@@ -13,6 +13,12 @@ abstract class CartDiscountCode with _$CartDiscountCode {
   const factory CartDiscountCode({
     required bool? applicable,
     required String? code,
+
+    /// Why the code is not [applicable], attached in code from the cart mutation's payload-level
+    /// `warnings` (`errorCode` = CartWarningCode, `errorMessage` = localized text). Absent from the
+    /// discountCodes JSON, so fromJson leaves them null; they're populated via copyWith after parsing.
+    String? errorCode,
+    String? errorMessage,
   }) = _CartDiscountCode;
 
   /// The CartDiscountCode from json

--- a/lib/models/src/cart/cart_dicount_code/cart_discount_code.freezed.dart
+++ b/lib/models/src/cart/cart_dicount_code/cart_discount_code.freezed.dart
@@ -15,7 +15,10 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CartDiscountCode {
 
- bool? get applicable; String? get code;
+ bool? get applicable; String? get code;/// Why the code is not [applicable], attached in code from the cart mutation's payload-level
+/// `warnings` (`errorCode` = CartWarningCode, `errorMessage` = localized text). Absent from the
+/// discountCodes JSON, so fromJson leaves them null; they're populated via copyWith after parsing.
+ String? get errorCode; String? get errorMessage;
 /// Create a copy of CartDiscountCode
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +31,16 @@ $CartDiscountCodeCopyWith<CartDiscountCode> get copyWith => _$CartDiscountCodeCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CartDiscountCode&&(identical(other.applicable, applicable) || other.applicable == applicable)&&(identical(other.code, code) || other.code == code));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CartDiscountCode&&(identical(other.applicable, applicable) || other.applicable == applicable)&&(identical(other.code, code) || other.code == code)&&(identical(other.errorCode, errorCode) || other.errorCode == errorCode)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,applicable,code);
+int get hashCode => Object.hash(runtimeType,applicable,code,errorCode,errorMessage);
 
 @override
 String toString() {
-  return 'CartDiscountCode(applicable: $applicable, code: $code)';
+  return 'CartDiscountCode(applicable: $applicable, code: $code, errorCode: $errorCode, errorMessage: $errorMessage)';
 }
 
 
@@ -48,7 +51,7 @@ abstract mixin class $CartDiscountCodeCopyWith<$Res>  {
   factory $CartDiscountCodeCopyWith(CartDiscountCode value, $Res Function(CartDiscountCode) _then) = _$CartDiscountCodeCopyWithImpl;
 @useResult
 $Res call({
- bool? applicable, String? code
+ bool? applicable, String? code, String? errorCode, String? errorMessage
 });
 
 
@@ -65,10 +68,12 @@ class _$CartDiscountCodeCopyWithImpl<$Res>
 
 /// Create a copy of CartDiscountCode
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? applicable = freezed,Object? code = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? applicable = freezed,Object? code = freezed,Object? errorCode = freezed,Object? errorMessage = freezed,}) {
   return _then(_self.copyWith(
 applicable: freezed == applicable ? _self.applicable : applicable // ignore: cast_nullable_to_non_nullable
 as bool?,code: freezed == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String?,errorCode: freezed == errorCode ? _self.errorCode : errorCode // ignore: cast_nullable_to_non_nullable
+as String?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -154,10 +159,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool? applicable,  String? code)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool? applicable,  String? code,  String? errorCode,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _CartDiscountCode() when $default != null:
-return $default(_that.applicable,_that.code);case _:
+return $default(_that.applicable,_that.code,_that.errorCode,_that.errorMessage);case _:
   return orElse();
 
 }
@@ -175,10 +180,10 @@ return $default(_that.applicable,_that.code);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool? applicable,  String? code)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool? applicable,  String? code,  String? errorCode,  String? errorMessage)  $default,) {final _that = this;
 switch (_that) {
 case _CartDiscountCode():
-return $default(_that.applicable,_that.code);case _:
+return $default(_that.applicable,_that.code,_that.errorCode,_that.errorMessage);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -195,10 +200,10 @@ return $default(_that.applicable,_that.code);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool? applicable,  String? code)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool? applicable,  String? code,  String? errorCode,  String? errorMessage)?  $default,) {final _that = this;
 switch (_that) {
 case _CartDiscountCode() when $default != null:
-return $default(_that.applicable,_that.code);case _:
+return $default(_that.applicable,_that.code,_that.errorCode,_that.errorMessage);case _:
   return null;
 
 }
@@ -210,11 +215,16 @@ return $default(_that.applicable,_that.code);case _:
 @JsonSerializable()
 
 class _CartDiscountCode extends CartDiscountCode {
-  const _CartDiscountCode({required this.applicable, required this.code}): super._();
+  const _CartDiscountCode({required this.applicable, required this.code, this.errorCode, this.errorMessage}): super._();
   factory _CartDiscountCode.fromJson(Map<String, dynamic> json) => _$CartDiscountCodeFromJson(json);
 
 @override final  bool? applicable;
 @override final  String? code;
+/// Why the code is not [applicable], attached in code from the cart mutation's payload-level
+/// `warnings` (`errorCode` = CartWarningCode, `errorMessage` = localized text). Absent from the
+/// discountCodes JSON, so fromJson leaves them null; they're populated via copyWith after parsing.
+@override final  String? errorCode;
+@override final  String? errorMessage;
 
 /// Create a copy of CartDiscountCode
 /// with the given fields replaced by the non-null parameter values.
@@ -229,16 +239,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CartDiscountCode&&(identical(other.applicable, applicable) || other.applicable == applicable)&&(identical(other.code, code) || other.code == code));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CartDiscountCode&&(identical(other.applicable, applicable) || other.applicable == applicable)&&(identical(other.code, code) || other.code == code)&&(identical(other.errorCode, errorCode) || other.errorCode == errorCode)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,applicable,code);
+int get hashCode => Object.hash(runtimeType,applicable,code,errorCode,errorMessage);
 
 @override
 String toString() {
-  return 'CartDiscountCode(applicable: $applicable, code: $code)';
+  return 'CartDiscountCode(applicable: $applicable, code: $code, errorCode: $errorCode, errorMessage: $errorMessage)';
 }
 
 
@@ -249,7 +259,7 @@ abstract mixin class _$CartDiscountCodeCopyWith<$Res> implements $CartDiscountCo
   factory _$CartDiscountCodeCopyWith(_CartDiscountCode value, $Res Function(_CartDiscountCode) _then) = __$CartDiscountCodeCopyWithImpl;
 @override @useResult
 $Res call({
- bool? applicable, String? code
+ bool? applicable, String? code, String? errorCode, String? errorMessage
 });
 
 
@@ -266,10 +276,12 @@ class __$CartDiscountCodeCopyWithImpl<$Res>
 
 /// Create a copy of CartDiscountCode
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? applicable = freezed,Object? code = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? applicable = freezed,Object? code = freezed,Object? errorCode = freezed,Object? errorMessage = freezed,}) {
   return _then(_CartDiscountCode(
 applicable: freezed == applicable ? _self.applicable : applicable // ignore: cast_nullable_to_non_nullable
 as bool?,code: freezed == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String?,errorCode: freezed == errorCode ? _self.errorCode : errorCode // ignore: cast_nullable_to_non_nullable
+as String?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/lib/models/src/cart/cart_dicount_code/cart_discount_code.g.dart
+++ b/lib/models/src/cart/cart_dicount_code/cart_discount_code.g.dart
@@ -10,7 +10,14 @@ _CartDiscountCode _$CartDiscountCodeFromJson(Map<String, dynamic> json) =>
     _CartDiscountCode(
       applicable: json['applicable'] as bool?,
       code: json['code'] as String?,
+      errorCode: json['errorCode'] as String?,
+      errorMessage: json['errorMessage'] as String?,
     );
 
 Map<String, dynamic> _$CartDiscountCodeToJson(_CartDiscountCode instance) =>
-    <String, dynamic>{'applicable': instance.applicable, 'code': instance.code};
+    <String, dynamic>{
+      'applicable': instance.applicable,
+      'code': instance.code,
+      'errorCode': instance.errorCode,
+      'errorMessage': instance.errorMessage,
+    };

--- a/lib/shopify/src/shopify_cart.dart
+++ b/lib/shopify/src/shopify_cart.dart
@@ -181,9 +181,10 @@ class ShopifyCart with ShopifyError {
     required String cartId,
     required List<String> discountCodes,
     bool reverse = false,
+    bool includeWarnings = false,
   }) async {
     final MutationOptions updateDiscountCodes = MutationOptions(
-      document: gql(updateCartDiscountCodesMutation),
+      document: gql(updateCartDiscountCodesMutation(includeWarnings: includeWarnings)),
       variables: {
         'cartId': cartId,
         'discountCodes': discountCodes,
@@ -195,9 +196,29 @@ class ShopifyCart with ShopifyError {
     checkForError(result,
         key: 'cartDiscountCodesUpdate', errorKey: 'userErrors');
 
-    return Cart.fromJson(
-        ((result.data!['cartDiscountCodesUpdate'] ?? const {})['cart'] ??
-            const {}));
+    final Map payload = result.data?['cartDiscountCodesUpdate'] ?? const {};
+    final Cart cart = Cart.fromJson(payload['cart'] ?? const {});
+    if (!includeWarnings) return cart;
+
+    // `warnings` (CartWarningCode + localized message) are payload-level, not linked to a specific
+    // code, so pair them positionally with the non-applicable codes and surface them on each
+    // CartDiscountCode (errorCode/errorMessage). In practice a single code is applied at a time → 1:1.
+    final List warnings = payload['warnings'] ?? const [];
+    if (warnings.isEmpty) return cart;
+    int w = 0;
+    final codes = <CartDiscountCode?>[];
+    for (final c in cart.discountCodes ?? const <CartDiscountCode?>[]) {
+      if (c != null && c.applicable == false && w < warnings.length) {
+        final warning = warnings[w++];
+        codes.add(c.copyWith(
+          errorCode: warning['code'] as String?,
+          errorMessage: warning['message'] as String?,
+        ));
+      } else {
+        codes.add(c);
+      }
+    }
+    return cart.copyWith(discountCodes: codes);
   }
 
   /// update Buyer identity in cart


### PR DESCRIPTION
Adds an opt-in way to learn **why** a discount code is not applicable, using the Storefront API's `cartDiscountCodesUpdate` payload `warnings`.

Closes #140.

### What
- New `bool includeWarnings = false` on `ShopifyCart.updateCartDiscountCodes(...)`.
- `false` (default): the mutation string and returned `Cart` are unchanged — safe on any Storefront API version.
- `true`: the mutation requests `warnings { code message target }`; the payload-level warnings are paired with the non-applicable codes and surfaced on two new nullable `CartDiscountCode` fields — `errorCode` (the `CartWarningCode`) and `errorMessage` (localized text).

### Why
`CartDiscountCode` only exposes `applicable`/`code`, so a rejected code gives no reason. `CartWarningCode` carries discount-specific reasons (`DISCOUNT_NOT_FOUND`, `DISCOUNT_CUSTOMER_NOT_ELIGIBLE`, `DISCOUNT_PURCHASE_NOT_IN_RANGE`, …) plus a localized `message`.

### Notes
- Backward compatible and additive. The `warnings` GraphQL field is gated behind the flag because it requires a recent Storefront API version — requesting it unconditionally would break callers on older versions.
- The mutation is assembled as head + optional `warnings` fragment + tail, so each piece stays a raw string and the GraphQL `$variables` aren't interpolated.
- Regenerated freezed/json for `CartDiscountCode`.
